### PR TITLE
fix(coding): replace declare -A with bash 3.2-compatible worktree map

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.27",
+      "version": "0.2.28",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "source": "./plugins/claude-coding"
     },
     {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.28](https://img.shields.io/badge/v0.2.28-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.29](https://img.shields.io/badge/v0.2.29-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.27](https://img.shields.io/badge/v0.2.27-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.28](https://img.shields.io/badge/v0.2.28-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.27](https://img.shields.io/badge/v0.2.27-blue?style=flat-square)
+# claude-coding ![v0.2.28](https://img.shields.io/badge/v0.2.28-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.28](https://img.shields.io/badge/v0.2.28-blue?style=flat-square)
+# claude-coding ![v0.2.29](https://img.shields.io/badge/v0.2.29-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh
+++ b/plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh
@@ -25,7 +25,9 @@ fi
 #   worktree /path
 #   HEAD <sha>
 #   branch refs/heads/<name>   (or "detached" for detached HEAD)
-# Uses a temp file (key=value lines) for bash 3.2 compat (no declare -A)
+# Uses a temp file (tab-separated key/value lines) for bash 3.2 compat
+# (no declare -A). Tab is safe as an in-band delimiter because
+# git-check-ref-format forbids control characters in refnames.
 WORKTREE_MAP_FILE=$(mktemp)
 trap 'rm -f "$WORKTREE_MAP_FILE"' EXIT
 current_wt=""
@@ -34,13 +36,16 @@ while IFS= read -r line; do
     current_wt="${line#worktree }"
   elif [[ "$line" == branch\ refs/heads/* ]]; then
     branch_name="${line#branch refs/heads/}"
-    printf '%s=%s\n' "$branch_name" "$current_wt" >> "$WORKTREE_MAP_FILE"
+    printf '%s\t%s\n' "$branch_name" "$current_wt" >> "$WORKTREE_MAP_FILE"
   fi
 done < <(git worktree list --porcelain)
 
-# Helper: look up branch in worktree map
+# Helper: look up branch in worktree map.
+# Uses awk with exact-string comparison on field 1 to avoid regex
+# metacharacter pitfalls (e.g. a `.` in a branch name matching any char)
+# and `=` pitfalls (branch names legally permit `=`).
 worktree_for() {
-  grep -m1 "^${1}=" "$WORKTREE_MAP_FILE" | cut -d= -f2- || true
+  awk -F'\t' -v b="$1" '$1 == b { print $2; exit }' "$WORKTREE_MAP_FILE"
 }
 
 # --- Merged branches ---

--- a/plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh
+++ b/plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh
@@ -25,16 +25,23 @@ fi
 #   worktree /path
 #   HEAD <sha>
 #   branch refs/heads/<name>   (or "detached" for detached HEAD)
-declare -A WORKTREE_MAP
+# Uses a temp file (key=value lines) for bash 3.2 compat (no declare -A)
+WORKTREE_MAP_FILE=$(mktemp)
+trap 'rm -f "$WORKTREE_MAP_FILE"' EXIT
 current_wt=""
 while IFS= read -r line; do
   if [[ "$line" == worktree\ * ]]; then
     current_wt="${line#worktree }"
   elif [[ "$line" == branch\ refs/heads/* ]]; then
     branch_name="${line#branch refs/heads/}"
-    WORKTREE_MAP["$branch_name"]="$current_wt"
+    printf '%s=%s\n' "$branch_name" "$current_wt" >> "$WORKTREE_MAP_FILE"
   fi
 done < <(git worktree list --porcelain)
+
+# Helper: look up branch in worktree map
+worktree_for() {
+  grep -m1 "^${1}=" "$WORKTREE_MAP_FILE" | cut -d= -f2- || true
+}
 
 # --- Merged branches ---
 echo "=== MERGED ==="
@@ -44,8 +51,9 @@ if [ -n "$PATTERN" ]; then
 fi
 while IFS= read -r branch; do
   [ -z "$branch" ] && continue
-  if [[ -n "${WORKTREE_MAP[$branch]+_}" ]]; then
-    echo "$branch [worktree:${WORKTREE_MAP[$branch]}]"
+  wt=$(worktree_for "$branch")
+  if [[ -n "$wt" ]]; then
+    echo "$branch [worktree:$wt]"
   else
     echo "$branch"
   fi
@@ -63,8 +71,9 @@ while read -r branch ts reldate; do
     continue
   fi
   if (( ts < CUTOFF )); then
-    if [[ -n "${WORKTREE_MAP[$branch]+_}" ]]; then
-      echo "$branch ($reldate) [worktree:${WORKTREE_MAP[$branch]}]"
+    wt=$(worktree_for "$branch")
+    if [[ -n "$wt" ]]; then
+      echo "$branch ($reldate) [worktree:$wt]"
     else
       echo "$branch ($reldate)"
     fi


### PR DESCRIPTION
## Summary
- fix(coding): replace declare -A with bash 3.2-compatible worktree map in find-candidates

## Changes
- `.claude-plugin/marketplace.json`
- `README.md`
- `plugins/claude-coding/.claude-plugin/plugin.json`
- `plugins/claude-coding/README.md`
- `plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh`

## Commits
- `8690c67` fix(coding): replace declare -A with bash 3.2-compatible worktree map in find-candidates

## Diff Stat
```
.claude-plugin/marketplace.json                     |  2 +-
 README.md                                           |  2 +-
 plugins/claude-coding/.claude-plugin/plugin.json    |  2 +-
 plugins/claude-coding/README.md                     |  2 +-
 .../clean-branches/scripts/find-candidates.sh       | 21 +++++++++++++++------
 5 files changed, 19 insertions(+), 10 deletions(-)
```