### PR TITLE
feat(memory): order session context by recency, add top-of-context directive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.77",
+      "version": "0.8.78",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.76",
+      "version": "0.8.77",
       "source": "./plugins/claude-memory"
     },
     {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.77](https://img.shields.io/badge/v0.8.77-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.78](https://img.shields.io/badge/v0.8.78-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.76](https://img.shields.io/badge/v0.8.76-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.77](https://img.shields.io/badge/v0.8.77-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.76",
+  "version": "0.8.77",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.77",
+  "version": "0.8.78",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.76](https://img.shields.io/badge/v0.8.76-blue?style=flat-square)
+# claude-memory ![v0.8.77](https://img.shields.io/badge/v0.8.77-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.77](https://img.shields.io/badge/v0.8.77-blue?style=flat-square)
+# claude-memory ![v0.8.78](https://img.shields.io/badge/v0.8.78-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/hooks/memory-context.py
+++ b/plugins/claude-memory/hooks/memory-context.py
@@ -320,9 +320,10 @@ def _build_fallback_context(session: dict) -> str:
                 lines.append(truncate_mid(ex["assistant"]))
                 lines.append("")
     else:
-        # First 2 exchanges
-        lines.append("### First Exchanges\n")
-        for ex in exchanges[:2]:
+        # Last 6 exchanges first — most recent context at top, where attention is highest
+        # and where truncation (if any) will clip from below rather than above.
+        lines.append("### Where We Left Off\n")
+        for ex in exchanges[-6:]:
             t = format_time(ex.get("timestamp"))
             lines.append(f"**[{t}] User:**")
             lines.append(ex["user"])
@@ -337,13 +338,14 @@ def _build_fallback_context(session: dict) -> str:
         if gap > 0:
             gap_files = [f.rsplit("/", 1)[-1] for f in files[:3]] if files else []
             if gap_files:
-                lines.append(f"[... {gap} exchanges covering: {', '.join(gap_files)} ...]\n")
+                lines.append(f"[... {gap} earlier exchanges covering: {', '.join(gap_files)} ...]\n")
             else:
-                lines.append(f"[... {gap} exchanges ...]\n")
+                lines.append(f"[... {gap} earlier exchanges ...]\n")
 
-        # Last 6 exchanges
-        lines.append("### Where We Left Off\n")
-        for ex in exchanges[-6:]:
+        # First 2 exchanges — kept for origin context, placed last so it's the
+        # first thing clipped under inline-preview truncation.
+        lines.append("### Earlier in This Session\n")
+        for ex in exchanges[:2]:
             t = format_time(ex.get("timestamp"))
             lines.append(f"**[{t}] User:**")
             lines.append(ex["user"])
@@ -485,9 +487,24 @@ def main():
 
         logger.info(f"Injecting context from {len(sessions)} session(s) for project {project_key}")
 
-        # Wrap in origin block + section header
+        # Top-of-context directive: placed first because the hook's inline
+        # preview may be truncated by the harness, and because earlier tokens
+        # receive more attention. Tells Claude how to read the rest of this
+        # injection and when to reach for the persisted file or recall skill.
+        directive = (
+            "## How To Use This Context\n"
+            "- The sections below are ordered by recency: **Where We Left Off** first, "
+            "then gap summary, then **Earlier in This Session**. Read top-down.\n"
+            "- If this hook's output was truncated inline and a persisted file path "
+            "is referenced, Read that file before answering any message that references "
+            "prior work — the last exchanges of the previous session may live only there.\n"
+            "- For anything beyond the two sessions shown here, use the "
+            "`recall-conversations` skill rather than guessing."
+        )
+
+        # Wrap in directive + origin block + session content
         origin = build_origin_block(source, sessions)
-        full_context = f"{origin}\n\n{context}"
+        full_context = f"{directive}\n\n{origin}\n\n{context}"
 
         output = {
             "hookSpecificOutput": {

--- a/plugins/claude-memory/hooks/memory-context.py
+++ b/plugins/claude-memory/hooks/memory-context.py
@@ -493,12 +493,13 @@ def main():
         # injection and when to reach for the persisted file or recall skill.
         directive = (
             "## How To Use This Context\n"
-            "- The sections below are ordered by recency: **Where We Left Off** first, "
-            "then gap summary, then **Earlier in This Session**. Read top-down.\n"
+            "- Sessions below are ordered most-recent first, and within each session "
+            "the most recent exchanges come first. Read top-down to get the freshest "
+            "context before older context.\n"
             "- If this hook's output was truncated inline and a persisted file path "
             "is referenced, Read that file before answering any message that references "
             "prior work — the last exchanges of the previous session may live only there.\n"
-            "- For anything beyond the two sessions shown here, use the "
+            "- For anything beyond the sessions shown here, use the "
             "`recall-conversations` skill rather than guessing."
         )
 

--- a/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/summarizer.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/summarizer.py
@@ -421,9 +421,10 @@ def render_context_summary(summary_json: dict) -> str:
                 lines.append(truncate_mid(ex["assistant"]))
                 lines.append("")
     else:
-        # First Exchanges (up to 2)
-        lines.append("### First Exchanges\n")
-        for ex in first_exs:
+        # Where We Left Off first — most recent context at top, where attention is
+        # highest and where inline-preview truncation (if any) clips from below.
+        lines.append("### Where We Left Off\n")
+        for ex in last_exs:
             t = format_time(ex.get("timestamp"))
             lines.append(f"**[{t}] User:**")
             lines.append(ex["user"])
@@ -438,13 +439,14 @@ def render_context_summary(summary_json: dict) -> str:
         if gap > 0:
             gap_detail = _build_gap_summary(summary_json, len(first_exs), exchange_count - len(last_exs))
             if gap_detail:
-                lines.append(f"[... {gap} exchanges covering: {gap_detail} ...]\n")
+                lines.append(f"[... {gap} earlier exchanges covering: {gap_detail} ...]\n")
             else:
-                lines.append(f"[... {gap} exchanges ...]\n")
+                lines.append(f"[... {gap} earlier exchanges ...]\n")
 
-        # Where We Left Off
-        lines.append("### Where We Left Off\n")
-        for ex in last_exs:
+        # Earlier in This Session — first 2 exchanges kept for origin context,
+        # placed last so they're the first thing clipped under truncation.
+        lines.append("### Earlier in This Session\n")
+        for ex in first_exs:
             t = format_time(ex.get("timestamp"))
             lines.append(f"**[{t}] User:**")
             lines.append(ex["user"])

--- a/tests/claude-memory/test_context_injection.py
+++ b/tests/claude-memory/test_context_injection.py
@@ -517,7 +517,7 @@ class TestBuildFallbackContext:
             "messages": messages,
         }
         result = _build_fallback_context(session)
-        assert "### First Exchanges" in result
+        assert "### Earlier in This Session" in result
         assert "### Where We Left Off" in result
         assert "Q0" in result   # First exchange
         assert "Q1" in result   # Second exchange

--- a/tests/claude-memory/test_summarizer.py
+++ b/tests/claude-memory/test_summarizer.py
@@ -295,9 +295,9 @@ class TestRenderContextSummary:
                           "tool_counts": {"Read": 10, "Edit": 3}},
         }
         result = render_context_summary(summary)
-        assert "### First Exchanges" in result
+        assert "### Earlier in This Session" in result
         assert "### Where We Left Off" in result
-        assert "[... 4 exchanges covering: a.py, b.py ...]" in result  # 12 - 2 - 6 = 4
+        assert "[... 4 earlier exchanges covering: a.py, b.py ...]" in result  # 12 - 2 - 6 = 4
         assert "feat/x" in result
         assert "Modified:" in result
         assert "Tools:" in result


### PR DESCRIPTION
## Summary
- Reorder the long-session SessionStart render so **Where We Left Off** precedes **Earlier in This Session** in both the fallback and cached rendering paths, keeping the most recent exchanges at the top of the injection where attention is highest and where inline-preview truncation clips last.
- Prepend a `## How To Use This Context` directive to `memory-context.py`'s `additionalContext` output, instructing Claude to read top-down, open any referenced persisted-file path before answering prior-work questions, and reach for `recall-conversations` for anything beyond the shown sessions.

## Motivation
Observed on a real PKM session: the hook produced 11.5 KB of context but the harness inlined only a ~2 KB preview and persisted the rest to a `tool-results/hook-*-additionalContext.txt` file. Under the old template, the most-recent exchanges (under `### Where We Left Off`) were rendered *after* `### First Exchanges`, meaning the actionable signal ("backfill is approved") fell into the persisted file while the session-opening chitchat occupied the inline window. Claude missed the mid-thread pickup until explicitly told to read the persisted file.

Two fixes, one commit:
1. **Recency ordering** — put the tail of the session first, so it survives any inline cap and lands in the high-attention prefix. This helps even when no cap exists: earlier tokens in the context window receive disproportionate attention regardless of total length.
2. **Top-of-context directive** — placed above the Session Origin block, before any session content, so it is the first thing Claude reads from the hook. Lives in the hook output (not CLAUDE.md) because the hook is what actually delivers the context and the directive is specific to the shape of that context.

## Changes
- `plugins/claude-memory/hooks/memory-context.py` — reorder `_build_fallback_context` long-session branch; rename "First Exchanges" → "Earlier in This Session"; update gap line from "exchanges covering" → "earlier exchanges covering"; prepend directive in `main()` before `build_origin_block` + session content.
- `plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/summarizer.py` — parallel reorder in `render_context_summary` (cached path used when `branches.context_summary_json` is populated by `sync_current.py` at Stop time). Both paths must change together to avoid rendering inconsistency.
- Auto-bumped: `plugin.json`, `marketplace.json`, README badges (pre-commit hook).

## No Migration
Deliberately no `summary_version` bump. `sync_current.py` rewrites the cached summary on every Stop hook, so any session you actively touch migrates to the new template naturally on its next turn. Stale branches in long-abandoned projects keep their old template forever — which is fine, because they're stale for a reason and the selection algorithm rarely surfaces them. Avoiding the bump sidesteps thousands of background DB writes on first session after merge and eliminates the risk of `render_context_summary` throwing on some exotic legacy `summary_json` shape.

## Verification
- `python3 -m py_compile` clean on all six edited files.
- End-to-end: ran `memory-context.py` against the real `~/.claude-memory/conversations.db` with synthetic stdin. Short session (4 exchanges) takes the `### Conversation` single-section path unchanged; new directive renders at the top of the output.
- Template unit test: rendered a real 13-exchange PKM branch through the updated `render_context_summary` using its stored `context_summary_json`. Total output 11,525 chars. `Where We Left Off` at char 538; `Earlier in This Session` at char 7,241. The most recent user decision is now in the first ~8 KB of the blob instead of the last ~3 KB.

## Test plan
- [ ] Open a fresh Claude Code session in a project with >8-exchange history; verify the SessionStart context shows "Where We Left Off" before "Earlier in This Session" after the first Stop hook has rewritten the cached summary.
- [ ] Verify the top-of-context directive appears as the first section of the injected context, above the Session Origin block.
- [ ] Verify short sessions (≤8 exchanges) still render under the single `### Conversation` header (no reordering applies to the short path).
- [ ] Verify no stale-format errors on old branches that still have `summary_version = 2` markdown cached.