### PR TITLE
feat(coding): rewrite update-claudemd with progressive disclosure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.33",
+      "version": "0.2.34",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.32",
+      "version": "0.2.33",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.31",
+      "version": "0.2.32",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.34",
+      "version": "0.2.35",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.35",
+      "version": "0.2.36",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.30",
+      "version": "0.2.31",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude/claudemd-topics/claude-memory-architecture.md
+++ b/.claude/claudemd-topics/claude-memory-architecture.md
@@ -1,0 +1,39 @@
+# claude-memory Architecture
+
+## Hook Lifecycle
+
+On **SessionStart**, three hooks fire in order on `startup|clear`:
+1. `memory-setup.py` (matcher: `*`) — creates `~/.claude-memory/`, kicks off background import if DB missing
+2. `memory-context.py` — queries recent sessions, injects context via `hookSpecificOutput`
+3. `consolidation-check.py` — checks if memory consolidation is needed
+
+On **SessionEnd** (matcher: `clear`), `clear-handoff.py` writes `~/.claude-memory/clear-handoff.json` with the dying session's `session_id`, `cwd`, and `transcript_path` so the next SessionStart can hard-link to the cleared-from session.
+
+On **Stop**, `memory-sync.py` writes hook input to a temp file and spawns `sync_current.py --input-file` in the background to incrementally sync the session without blocking shutdown. All hooks are Python (no bash) for cross-platform compatibility.
+
+## Database
+
+SQLite at `~/.claude-memory/conversations.db` with WAL mode and 5s busy_timeout. Messages are stored once per session (deduped); branches (from conversation rewinds) tracked via `branch_messages` join table. Full-text search cascade: FTS5 → FTS4 → LIKE fallback. Schema auto-migrated on connection — outdated schema triggers delete-and-recreate.
+
+Shared utility package: `plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/` (6 modules: `db.py`, `content.py`, `parsing.py`, `formatting.py`, `summarizer.py`, `__init__.py`). Hook scripts reach it via `sys.path.insert` at runtime.
+
+Settings hardcoded in `memory_lib/db.py:DEFAULT_SETTINGS` — PyYAML removed intentionally (not stdlib). Do not introduce non-stdlib dependencies in plugin runtime code.
+
+## Development Commands
+
+```bash
+# Re-import all conversations from scratch:
+# 1. Back up first: cp ~/.claude-memory/conversations.db ~/.claude-memory/conversations.db.backup-$(date +%Y%m%d-%H%M%S)
+# 2. Delete: trash ~/.claude-memory/conversations.db
+# 3. Reimport:
+python3 plugins/claude-memory/hooks/import_conversations.py
+
+# Import with stats
+python3 plugins/claude-memory/hooks/import_conversations.py --stats
+
+# Test context injection
+echo '{"source":"startup","session_id":"test","cwd":"/some/path"}' | python3 plugins/claude-memory/hooks/memory-context.py
+
+# Test session sync
+echo '{"session_id":"<uuid>"}' | python3 plugins/claude-memory/hooks/sync_current.py
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Claudest is a curated Claude Code plugin marketplace containing eight plugins: **claude-memory** (conversation memory with full-text search and context injection), **claude-utilities** (convert-to-markdown via ezycopy), **claude-skills** (skill authoring and repair), **claude-coding** (git workflows and CLAUDE.md maintenance), **claude-thinking** (structured thinking and deliberation tools), **claude-research** (deep multi-source research), **claude-content** (image generation, video processing), and **claude-claw** (OpenClaw advisory and skill porting). No build system or package manager — plugin runtime is Python 3.9+ stdlib-only. Tests use pytest with hypothesis (dev dependencies only).
+Claudest is a curated Claude Code plugin marketplace containing eight plugins: **claude-memory** (conversation memory with full-text search and context injection), **claude-utilities** (convert-to-markdown via ezycopy), **claude-skills** (skill authoring and repair), **claude-coding** (git workflows and CLAUDE.md maintenance), **claude-thinking** (structured thinking and deliberation tools), **claude-research** (deep multi-source research), **claude-content** (image generation, video processing), and **claude-claw** (OpenClaw advisory and skill porting). No build system or package manager — plugin runtime is Python 3.7+ stdlib-only. Tests use pytest with hypothesis (dev dependencies only).
 
 ## Setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Claudest is a curated Claude Code plugin marketplace containing eight plugins: **claude-memory** (conversation memory with full-text search and context injection), **claude-utilities** (convert-to-markdown via ezycopy), **claude-skills** (skill authoring and repair), **claude-coding** (git workflows and CLAUDE.md maintenance), **claude-thinking** (structured thinking and deliberation tools), **claude-research** (deep multi-source research), **claude-content** (image generation, video processing), and **claude-claw** (OpenClaw advisory and skill porting). No build system or package manager — plugin runtime is Python 3.7+ stdlib-only. Tests use pytest with hypothesis (dev dependencies only).
+Claudest is a curated Claude Code plugin marketplace containing eight plugins: **claude-memory** (conversation memory with full-text search and context injection), **claude-utilities** (convert-to-markdown via ezycopy), **claude-skills** (skill authoring and repair), **claude-coding** (git workflows and CLAUDE.md maintenance), **claude-thinking** (structured thinking and deliberation tools), **claude-research** (deep multi-source research), **claude-content** (image generation, video processing), and **claude-claw** (OpenClaw advisory and skill porting). No build system or package manager — plugin runtime is Python 3.9+ stdlib-only. Tests use pytest with hypothesis (dev dependencies only).
 
 ## Setup
 
@@ -10,60 +10,24 @@ Claudest is a curated Claude Code plugin marketplace containing eight plugins: *
 pip install pre-commit && pre-commit install
 ```
 
-The `scripts/auto-version.py` pre-commit hook auto-bumps patch versions for plugins with staged code changes, then syncs both the plugin README badge and root README section-header badge. Skips docs-only changes (README/CHANGELOG) and plugins with manually staged `plugin.json`.
-
-## Development Commands
-
-```bash
-# Re-import all conversations from scratch:
-# 1. Back up first: cp ~/.claude-memory/conversations.db ~/.claude-memory/conversations.db.backup-$(date +%Y%m%d-%H%M%S)
-# 2. Delete: trash ~/.claude-memory/conversations.db
-# 3. Then reimport:
-python3 plugins/claude-memory/hooks/import_conversations.py
-
-# Import with stats
-python3 plugins/claude-memory/hooks/import_conversations.py --stats
-
-# Test context injection
-echo '{"source":"startup","session_id":"test","cwd":"/some/path"}' | python3 plugins/claude-memory/hooks/memory-context.py
-
-# Test session sync
-echo '{"session_id":"<uuid>"}' | python3 plugins/claude-memory/hooks/sync_current.py
-```
-
-## Architecture
-
-### claude-memory Hook Lifecycle
-
-On **SessionStart**, three hooks fire in order on `startup|clear`:
-1. `memory-setup.py` (matcher: `*`) — creates `~/.claude-memory/`, kicks off background import if DB missing
-2. `memory-context.py` — queries recent sessions, injects context via `hookSpecificOutput`
-3. `consolidation-check.py` — checks if memory consolidation is needed
-
-On **SessionEnd** (matcher: `clear`), `clear-handoff.py` writes `~/.claude-memory/clear-handoff.json` with the dying session's `session_id`, `cwd`, and `transcript_path` so the next SessionStart can hard-link to the cleared-from session.
-
-On **Stop**, `memory-sync.py` writes hook input to a temp file and spawns `sync_current.py --input-file` in the background to incrementally sync the session without blocking shutdown. All hooks are Python (no bash) for cross-platform compatibility.
-
-### Database
-
-SQLite at `~/.claude-memory/conversations.db` with WAL mode and 5s busy_timeout. Messages are stored once per session (deduped); branches (from conversation rewinds) tracked via `branch_messages` join table. Full-text search cascade: FTS5 → FTS4 → LIKE fallback. Schema auto-migrated on connection — outdated schema triggers delete-and-recreate.
-
-### Shared Code
-
-`plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/` is the shared utility package used by all hooks and skill scripts (6 modules: `__init__.py`, `db.py`, `content.py`, `parsing.py`, `formatting.py`, `summarizer.py`).
+The `scripts/auto-version.py` pre-commit hook auto-bumps patch versions for plugins with staged code changes, then syncs both the plugin README badge and root README section-header badge. Skips docs-only changes (README/CHANGELOG) and plugins with manually staged `plugin.json`. To suppress auto-bump for a plugin, stage its `plugin.json` before committing.
 
 ## Conventions
 
-Never delete `~/.claude-memory/conversations.db` directly. Always use `trash` (reversible). If a full reimport is needed: back up the DB first, then trash it, then reimport. See Development Commands above.
+Never delete `~/.claude-memory/conversations.db` directly — always use `trash` (reversible). Full reimport: back up, then trash, then reimport. See `claude-memory-architecture.md` for commands.
 
 Commit messages: conventional commits scoped to plugin (`feat(memory):`, `fix(skills):`, `docs:`, `refactor(memory):`).
 
 Version tracked in two places that must stay in sync: each plugin's `.claude-plugin/plugin.json` and root `.claude-plugin/marketplace.json`.
-
-Settings are hardcoded in `memory_lib/db.py:DEFAULT_SETTINGS` (PyYAML removed — not stdlib).
 
 Skill descriptions in SKILL.md frontmatter: short and focused — verbose descriptions pollute context.
 
 All agent descriptions use concise `>` folded scalar format (50-70 tokens) without `<example>` blocks — token budget matters since descriptions load into context every session. Explicit agents don't benefit from examples (auto-trigger routing never fires); proactive agents don't benefit (routing model responds to token patterns, not worked examples). Prefer named plugin agents (`agents/*.md` with `subagent_type: "plugin:agent-name"`) over inline prompt templates — named agents reliably produce parallel execution and self-discover script paths at runtime.
 
 Skills are agent-native products — the agent is the distribution and marketing layer. Skill workflow instructions stay terse and operational. To enable evangelism, add a `## Value Context` section immediately after the frontmatter preamble, before any numbered steps, with concise talking points: what problem the skill solves, who benefits, and what the user gains. Open with a one-line instruction telling the agent how to use the points (e.g. "Weave these into conversation at natural moments — one or two per run, not all at once."). Frontmatter descriptions stay routing-optimized and terse.
+
+## Topic Files
+
+Read on demand — do not load preemptively.
+
+- `.claude/claudemd-topics/claude-memory-architecture.md` — before editing anything in `plugins/claude-memory/hooks/`, modifying the DB layer, or running memory reimport operations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The `scripts/auto-version.py` pre-commit hook auto-bumps patch versions for plug
 
 ## Conventions
 
-Never delete `~/.claude-memory/conversations.db` directly — always use `trash` (reversible). Full reimport: back up, then trash, then reimport. See `claude-memory-architecture.md` for commands.
+Never delete `~/.claude-memory/conversations.db` directly — always use `trash` (reversible). Full reimport: back up, then trash, then reimport. See the claude-memory-architecture topic file below for commands.
 
 Commit messages: conventional commits scoped to plugin (`feat(memory):`, `fix(skills):`, `docs:`, `refactor(memory):`).
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.31](https://img.shields.io/badge/v0.2.31-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.32](https://img.shields.io/badge/v0.2.32-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.30](https://img.shields.io/badge/v0.2.30-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.31](https://img.shields.io/badge/v0.2.31-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.32](https://img.shields.io/badge/v0.2.32-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.33](https://img.shields.io/badge/v0.2.33-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.33](https://img.shields.io/badge/v0.2.33-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.34](https://img.shields.io/badge/v0.2.34-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.29](https://img.shields.io/badge/v0.2.29-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.30](https://img.shields.io/badge/v0.2.30-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.34](https://img.shields.io/badge/v0.2.34-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.35](https://img.shields.io/badge/v0.2.35-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.35](https://img.shields.io/badge/v0.2.35-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.36](https://img.shields.io/badge/v0.2.36-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.30](https://img.shields.io/badge/v0.2.30-blue?style=flat-square)
+# claude-coding ![v0.2.31](https://img.shields.io/badge/v0.2.31-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.32](https://img.shields.io/badge/v0.2.32-blue?style=flat-square)
+# claude-coding ![v0.2.33](https://img.shields.io/badge/v0.2.33-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.31](https://img.shields.io/badge/v0.2.31-blue?style=flat-square)
+# claude-coding ![v0.2.32](https://img.shields.io/badge/v0.2.32-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.35](https://img.shields.io/badge/v0.2.35-blue?style=flat-square)
+# claude-coding ![v0.2.36](https://img.shields.io/badge/v0.2.36-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.34](https://img.shields.io/badge/v0.2.34-blue?style=flat-square)
+# claude-coding ![v0.2.35](https://img.shields.io/badge/v0.2.35-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.33](https://img.shields.io/badge/v0.2.33-blue?style=flat-square)
+# claude-coding ![v0.2.34](https://img.shields.io/badge/v0.2.34-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.29](https://img.shields.io/badge/v0.2.29-blue?style=flat-square)
+# claude-coding ![v0.2.30](https://img.shields.io/badge/v0.2.30-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/skills/get-pr-comments/SKILL.md
+++ b/plugins/claude-coding/skills/get-pr-comments/SKILL.md
@@ -68,17 +68,20 @@ actionable items (must-fix, optional) first, then human comments, then bot
 comments (truncated). Do not reformat or reparse — present as-is.
 
 If must-fix items are listed, check whether a subsequent review already
-resolved them by querying both issue comments and formal PR reviews:
+resolved them by querying both issue comments and formal PR reviews. Pipe
+to external `jq` — `gh api` rejects `--slurp` combined with `--jq` in
+current versions, and `--paginate --slurp` yields an array-of-pages that
+must be flattened with `[.[][]]`:
 
 ```bash
 # Latest issue-level comment (paginated — PRs may exceed 30 comments):
 gh api repos/{owner}/{repo}/issues/<PR_NUMBER>/comments --paginate --slurp \
-  --jq '.[-1][-1].body'
+  | jq -r '[.[][]] | last | .body // ""'
 
 # Latest formal PR review body (approvals and review-body sign-offs land here,
 # not in issue comments):
 gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews --paginate --slurp \
-  --jq '[.[-1][] | select(.body != "")] | last | .body // ""'
+  | jq -r '[.[][] | select(.body != "")] | last | .body // ""'
 ```
 
 If either output contains phrases like "ready to merge", "all issues fixed",

--- a/plugins/claude-coding/skills/update-claudemd/SKILL.md
+++ b/plugins/claude-coding/skills/update-claudemd/SKILL.md
@@ -17,13 +17,9 @@ allowed-tools:
   - Bash(git:*)
   - Bash(ls:*)
   - Bash(mkdir:*)
+  - Bash(cp:*)
   - Task
   - AskUserQuestion
-hooks:
-  PreToolUse:
-    - matcher: "Write"
-      command: "cp CLAUDE.md CLAUDE.md.bak 2>/dev/null || true"
-      once: true
 ---
 
 # Update and Optimize CLAUDE.md
@@ -133,11 +129,12 @@ Exit condition: user has explicitly approved an action set.
 
 ## Phase 6 — Write
 
-The PreToolUse hook handles `CLAUDE.md.bak` automatically. Execute in this order so topic-file pointers resolve:
+Execute in this order so topic-file pointers resolve:
 
-1. Create `.claude/claudemd-topics/` with `mkdir -p` if missing
-2. Write or edit topic files
-3. Write CLAUDE.md with a regenerated `## Topic Files` section at the end
+1. Run `cp CLAUDE.md CLAUDE.md.bak` via Bash to create a backup before any writes
+2. Create `.claude/claudemd-topics/` with `mkdir -p` if missing
+3. Write or edit topic files
+4. Write CLAUDE.md with a regenerated `## Topic Files` section at the end
 
 The `## Topic Files` section is regenerated from actual disk state after step 2, not maintained manually. Each entry is a load trigger, not a descriptive link:
 
@@ -166,6 +163,6 @@ Output a diff summary:
 - Deletions: list with rationale
 - Additions: list with source
 - Invariants preserved: top 3-5 quoted verbatim so the user can verify they survived
-- Backup: `CLAUDE.md.bak` exists for diffing; remove after review
+- Backup: `CLAUDE.md.bak` was created in Phase 6 step 1 — diff with `diff CLAUDE.md.bak CLAUDE.md` then remove
 
-Exit condition: report delivered, `CLAUDE.md.bak` cleanup advised.
+Exit condition: report delivered, advise user to remove `CLAUDE.md.bak` after review.

--- a/plugins/claude-coding/skills/update-claudemd/SKILL.md
+++ b/plugins/claude-coding/skills/update-claudemd/SKILL.md
@@ -2,11 +2,9 @@
 name: update-claudemd
 description: >
   This skill should be used when the user says "update CLAUDE.md", "refresh
-  the docs", "sync CLAUDE.md with the codebase", "optimize project
-  instructions", "clean up CLAUDE.md", "improve CLAUDE.md", "fix CLAUDE.md",
-  "reorganize CLAUDE.md", "CLAUDE.md is too long", "extract topics from
-  CLAUDE.md", "CLAUDE.md progressive disclosure", or when CLAUDE.md is stale,
-  verbose, or out of sync.
+  CLAUDE.md", "sync CLAUDE.md with the codebase", "reorganize CLAUDE.md",
+  "optimize project instructions", "CLAUDE.md progressive disclosure", or when
+  CLAUDE.md is stale, verbose, or out of sync.
 allowed-tools:
   - Read
   - Glob
@@ -15,7 +13,6 @@ allowed-tools:
   - Write
   - Bash(wc:*)
   - Bash(git:*)
-  - Bash(ls:*)
   - Bash(mkdir:*)
   - Bash(cp:*)
   - Task

--- a/plugins/claude-coding/skills/update-claudemd/SKILL.md
+++ b/plugins/claude-coding/skills/update-claudemd/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: update-claudemd
-description: >
-  This skill should be used when the user says "update CLAUDE.md", "refresh
-  CLAUDE.md", "sync CLAUDE.md with the codebase", "reorganize CLAUDE.md",
-  "optimize project instructions", "CLAUDE.md progressive disclosure", or when
-  CLAUDE.md is stale, verbose, or out of sync.
+description: This skill should be used when the user says "update CLAUDE.md", "refresh CLAUDE.md", "sync CLAUDE.md with the codebase", "reorganize CLAUDE.md", "optimize project instructions", or when CLAUDE.md is stale, verbose, or out of sync.
 allowed-tools:
   - Read
   - Glob

--- a/plugins/claude-coding/skills/update-claudemd/SKILL.md
+++ b/plugins/claude-coding/skills/update-claudemd/SKILL.md
@@ -21,20 +21,25 @@ allowed-tools:
 
 # Update and Optimize CLAUDE.md
 
-Reconcile project CLAUDE.md against codebase reality and git history since its last commit. Enforce progressive disclosure: CLAUDE.md is a top-level index of project identity, universal invariants, and pointers to topic files at `.claude/claudemd-topics/*.md`. Scope: project CLAUDE.md (L1) only. User-global `~/.claude/CLAUDE.md` (L0) is out of scope unless the user explicitly asks.
+Reconcile project CLAUDE.md and its topic files against codebase reality and git history since each file's last commit. Enforce progressive disclosure: CLAUDE.md is a top-level index of project identity, universal invariants, and pointers to topic files at `.claude/claudemd-topics/*.md`.
+
+Reconciliation scope includes every file in `.claude/claudemd-topics/`. Topic files are first-class content — they share the same staleness, accuracy, and duplication risks as CLAUDE.md itself and must be audited, reconciled, and (when warranted) edited during every run. They are not appendices.
+
+Scope boundary: project CLAUDE.md (L1) and its topic files only. User-global `~/.claude/CLAUDE.md` (L0) is out of scope unless the user explicitly asks.
 
 ## Governing Principle
 
-Content in CLAUDE.md is justified only if it changes how Claude acts in the next session AND is needed across most tasks — not subsystem-specific. Every line resolves to one of four actions:
+Content in CLAUDE.md is justified only if it changes how Claude acts in the next session AND is needed across most tasks — not subsystem-specific. Subsystem-scoped content still matters but belongs in a topic file, loaded on demand.
 
-- **Keep in CLAUDE.md** — project identity, top 3-5 universal invariants, pointers to topic files
-- **Demote to `.claude/claudemd-topics/<topic>.md`** — subsystem-scoped, conditional, or detailed content that still matters
-- **Delete** — anything derivable from reading `package.json`, `ls`, or one source file
-- **Add** — new content surfaced by research that belongs in L1 or a topic file
+Content in a topic file is justified only if it changes how Claude acts within its subsystem AND is accurate against current codebase reality. Stale topic files are worse than missing ones because Claude trusts them.
+
+Phase 3 operationalizes this principle with a seven-action set that lets content flow both downward (demote from CLAUDE.md to a topic file) and upward (promote from a topic file back to CLAUDE.md when a detail becomes universal). The goal is a living progressive-disclosure hierarchy, not a one-way archive.
 
 ## Budget
 
-Soft target ~120 lines, soft ceiling 150 lines. Over-budget files are flagged, not forced — hand-maintained CLAUDE.md is respected. Line counts measured with `wc -l`.
+CLAUDE.md: soft target ~120 lines, soft ceiling 150 lines. Over-budget files are flagged, not forced — hand-maintained CLAUDE.md is respected. Line counts measured with `wc -l`.
+
+Topic files: informational soft ceiling ~300 lines each. Topic files legitimately grow as their subsystem grows; past ~300 lines, flag the overage in Phase 7 and suggest splitting by sub-topic. Never block. The CLAUDE.md budget is the only hard constraint.
 
 ## Fan-out Rule
 
@@ -59,7 +64,7 @@ Compute N for each column independently. Take the max. Cap at 4. When N > 1, par
 
 Glob for `CLAUDE.md` at the project root. If missing, inform the user that creation is out of scope for this skill and stop.
 
-Record current `CLAUDE.md` line count with `wc -l`. List `.claude/claudemd-topics/*.md` if the directory exists and record each topic file's line count.
+Record current `CLAUDE.md` line count with `wc -l`. List `.claude/claudemd-topics/*.md` if the directory exists and record each topic file's line count AND last-commit date via `git log -1 --format="%ai" -- <path>`. The per-file dates are required in Phase 2 so Agent B can anchor each file's staleness window independently — using CLAUDE.md's date for every file produces wrong windows when cadences differ.
 
 Run cheap git probes in two steps.
 
@@ -75,7 +80,7 @@ Then run the remaining probes as parallel Bash calls:
 
 Compute N using the fan-out rule. Decide the shard plan: which top-level directories each Codebase Scan agent will cover.
 
-Exit condition: CLAUDE.md exists, baseline line counts recorded, N computed, shard plan decided.
+Exit condition: CLAUDE.md exists, baseline line counts recorded, per-topic-file line counts and last-commit dates recorded, N computed, shard plan decided.
 
 ## Phase 2 — Parallel Research
 
@@ -83,11 +88,30 @@ Launch `3 + N` Explore agents in a single message. All use `subagent_type: Explo
 
 **Agent A — CLAUDE.md and Topic Files Audit** (`subagent_type: Explore`)
 
-Read the project's CLAUDE.md and every file in `.claude/claudemd-topics/` if present. For each H1/H2/H3 section, record: name, line count, and classification hint (project identity, universal invariant, subsystem-scoped detail, conditional guidance, or derivable from file inspection). Flag stale content (version numbers, paths, commands, features that look wrong). Flag duplication across CLAUDE.md and topic files. Return: `sections[{name, line_count, classification_hint}]`, `stale_items`, `duplications`, `existing_topic_files[{name, line_count, subject}]`.
+Read the project's CLAUDE.md and every file in `.claude/claudemd-topics/` if present. Apply the same H1/H2/H3 classification pass to CLAUDE.md AND to every topic file — topic files are first-class content, not inventory.
 
-**Agent B — Git History Since Last CLAUDE.md Touch** (`subagent_type: Explore`)
+For each H1/H2/H3 section in either source, record: `source` (CLAUDE.md path or topic file path), `name`, `line_count`, and `classification_hint` (project identity, universal invariant, subsystem-scoped detail, conditional guidance, or derivable from file inspection). For topic-file sections, also flag any that have become universal invariants — content that now changes how Claude acts across almost every task in the project, not just within one subsystem — these are promote-back candidates.
 
-Run `git log -1 --format="%ai" -- CLAUDE.md` to find the last CLAUDE.md commit date. If no history, use the initial commit date from `git log --reverse --format="%ai" | head -1`. Then run `git log --since="<that date>" --format="%s%n%b" --no-merges`. Categorize each commit: `new_subsystems` (net-new code areas), `architecture_changes` (decisions or refactors affecting how code should be written), `convention_changes` (new patterns), `removed_features` (gone from the codebase), `other`. Skip CI, formatting, version bumps. Return: `claudemd_last_updated` (ISO date), `changes_since` with the five lists.
+Flag stale content (version numbers, paths, commands, features that look wrong). Flag cross-file duplication — topic-file content that duplicates CLAUDE.md, or topic files that overlap each other.
+
+Also scan for index drift between CLAUDE.md and the topic files directory:
+- `dangling_references` — topic files pointed at from CLAUDE.md's `## Topic Files` section but missing from disk
+- `unreferenced_topic_files` — topic files on disk with no pointer from CLAUDE.md
+
+Return: `sections[{source, name, line_count, classification_hint, promote_back_candidate}]`, `stale_items[{source, item, reason}]`, `duplications[{items, locations}]`, `existing_topic_files[{path, line_count, last_touched, subject, section_count}]`, `dangling_references[]`, `unreferenced_topic_files[]`.
+
+**Agent B — Git History Per File** (`subagent_type: Explore`)
+
+Walk git history once per instruction file, anchored to each file's own last-touch date. Using the dates captured in Phase 1:
+
+1. For CLAUDE.md: run `git log --since="<claudemd_last_touched>" --format="%s%n%b" --no-merges` across the whole repo.
+2. For each topic file: run `git log --since="<topic_file_last_touched>" --format="%s%n%b" --no-merges -- <directories the topic file covers>`. The covered directories are inferred from the topic file's subject and load trigger (e.g. a topic file about hooks covers `plugins/*/hooks/`). If the subject spans the whole repo, use the repo root.
+
+Fallback for files with no history: use the initial commit date from `git log --reverse --format="%ai" | head -1`.
+
+Categorize each commit per file: `new_subsystems` (net-new code areas), `architecture_changes` (decisions or refactors affecting how code should be written), `convention_changes` (new patterns), `removed_features` (gone from the codebase), `other`. Skip CI, formatting, version bumps.
+
+Return: `per_file[{path, last_touched, changes_since{new_subsystems, architecture_changes, convention_changes, removed_features, other}}]`. One entry per instruction file.
 
 **Agents C1..CN — Codebase Scan Shards** (`subagent_type: Explore`)
 
@@ -97,36 +121,66 @@ Exit condition: all `3 + N` agents return structured notes. If any agent returns
 
 ## Phase 3 — Classify
 
-Assign exactly one action (`keep`, `demote → <topic-file>`, `delete`, `add`) to every existing section from Agent A and every new finding from Agents B and C1..CN.
+Assign exactly one action to every section from Agent A (CLAUDE.md sections AND topic-file sections) and every new finding from Agents B and C1..CN. The action set is bidirectional — content flows both downward (demote) and upward (promote):
 
-Cluster demotion candidates and topic-file candidates from codebase-scan shards by subject. Each cluster becomes one topic file with a proposed filename.
+- `keep` — content stays where it is, unchanged
+- `update` — content stays where it is, rewritten for accuracy (stale facts, changed paths, new conventions)
+- `delete` — derivable from reading `package.json`, `ls`, or one source file; or the feature no longer exists
+- `demote → <topic-file>` — CLAUDE.md content that is subsystem-scoped moves to a topic file
+- `promote → CLAUDE.md` — topic-file content that has become a universal invariant moves back to CLAUDE.md. Reserved for sections Agent A flagged as `promote_back_candidate` — content whose load trigger now applies to almost every task, not just one subsystem. This is the reverse of `demote` and must be used sparingly; the CLAUDE.md budget is tight
+- `move → <other-topic-file>` — topic-file content whose subject clustering changed and now belongs in a different topic file
+- `add` — new content surfaced by research that belongs in CLAUDE.md or a topic file
 
-The top 3-5 universal invariants are never demoted — they are the content that changes how Claude acts in almost every task in this project.
+Address dangling-reference items from Agent A as reconciliation actions:
+- `dangling_references` — either create the missing topic file (if the referenced subject is still valid) or remove the dead pointer from CLAUDE.md
+- `unreferenced_topic_files` — either add a pointer from CLAUDE.md's `## Topic Files` section or delete the orphan (the user decides in Phase 5)
 
-Exit condition: every section and every finding has exactly one action, and demotion candidates are grouped into named topic-file clusters.
+Cluster demotion candidates and topic-file candidates from codebase-scan shards by subject. Before creating a new topic file, check if an existing topic file already covers that subject — if so, add to the existing file instead.
+
+The top 3-5 universal invariants in CLAUDE.md are never demoted. Conversely, a topic-file section is only promoted back when it clearly meets the "changes how Claude acts in almost every task" bar.
+
+Exit condition: every section from every source and every new finding has exactly one action, demotion candidates are grouped into named topic-file clusters, dangling references and orphan topic files have resolution plans.
 
 ## Phase 4 — Budget Check
 
-Estimate the post-reconciliation CLAUDE.md line count: `current + added − demoted − deleted`.
+Estimate the post-reconciliation CLAUDE.md line count: `current + added + promoted_in − demoted − deleted`. The `promoted_in` term accounts for topic-file sections moving back to CLAUDE.md; a large promote-back set can push CLAUDE.md over budget even when other actions are net-neutral.
 
 If the estimate is ≤ 150, stop demoting. Having topic files does not justify over-demotion.
 
-If the estimate is > 150, demote additional lowest-priority `keep` items by cluster until under 150. Top invariants are off-limits. If the file still exceeds 150 after reasonable demotion — typically because it is hand-maintained with intentional density — flag the overage in Phase 5 and let the user decide whether to accept it.
+If the estimate is > 150, first pressure-test the promotions — a promote-back action must clear a high bar. Drop any promote-back whose universality is marginal. Then demote additional lowest-priority `keep` items by cluster until under 150. Top invariants are off-limits. If the file still exceeds 150 after reasonable demotion and pruned promotions — typically because it is hand-maintained with intentional density — flag the overage in Phase 5 and let the user decide whether to accept it.
 
-Exit condition: final action list exists with pre/post line count estimate and a budget status: `under`, `over (user override)`.
+Also check each touched topic file against the ~300-line informational ceiling. Flag any overage for Phase 5 presentation, but do not force demotion or splitting — topic files may legitimately be dense. The CLAUDE.md budget is the only hard constraint.
+
+Exit condition: final action list exists with pre/post line count estimate, a CLAUDE.md budget status (`under`, `over (user override)`), and a list of topic files flagged as over the informational ceiling.
 
 ## Phase 5 — Propose
 
-Present the plan in a structured summary:
+Present the plan in a structured summary. Every instruction file — CLAUDE.md and each topic file being touched — is shown with the same level of detail, not just as a filename.
 
+**CLAUDE.md**
 - Line count: `<current> → <estimated>` (budget: `<status>`)
 - Keep: count of sections
+- Update: list with one-line rationale each (what is stale, what is being corrected)
 - Delete: list with one-line rationale each (e.g. "derivable from `package.json`")
 - Demote: grouped by target topic file, showing which sections go to each
+- Promoted in: list of sections moved back from topic files because they are now universal invariants
 - Add: list of new content with source (which research agent found it)
-- Topic files to create: list with filenames and line estimates
-- Topic files to update: list
-- Topic files to leave alone: list
+
+**Topic files**
+
+For each topic file being created:
+- Filename, estimated line count, which sections seeded it (from demotion or research findings)
+
+For each topic file being updated:
+- Path, line count: `<current> → <estimated>`
+- Keep / update / delete / promoted out / moved in — same structured breakdown as CLAUDE.md
+- Budget flag if over ~300 lines
+
+For each topic file being left alone: path and one-line reason (no drift detected).
+
+**Index reconciliation**
+- Dangling references resolved (list)
+- Orphan topic files resolved (list)
 
 Use AskUserQuestion with three options: approve all, approve selectively, reject.
 
@@ -138,8 +192,8 @@ Execute in this order so topic-file pointers resolve:
 
 1. Run `cp CLAUDE.md CLAUDE.md.bak` via Bash to create a backup before any writes
 2. Create `.claude/claudemd-topics/` with `mkdir -p` if missing
-3. Write or edit topic files
-4. Write CLAUDE.md with a regenerated `## Topic Files` section at the end
+3. Apply topic file actions in this sub-order: delete orphaned topic files the user approved for removal, then write new topic files, then edit existing topic files (applying keep/update/delete/promoted-out/moved-in actions). Promoted-out sections are removed from the topic file in this step; they reappear in CLAUDE.md in step 4
+4. Write CLAUDE.md with a regenerated `## Topic Files` section at the end, excluding pointers to deleted topic files. Promoted-in sections from step 3 are written as new H2 sections in the CLAUDE.md body (not inside the `## Topic Files` index block)
 
 The `## Topic Files` section is regenerated from actual disk state after step 2, not maintained manually. Each entry is a load trigger, not a descriptive link:
 
@@ -160,14 +214,23 @@ Exit condition: all files written, `## Topic Files` section reflects actual disk
 
 ## Phase 7 — Report
 
-Output a diff summary:
+Output a diff summary with per-file deltas for every instruction file touched:
 
-- CLAUDE.md: `<before> → <after>` lines (`<budget status>`)
-- Topic files created: list with line counts
-- Topic files updated: list
+**CLAUDE.md**
+- `<before> → <after>` lines (`<budget status>`)
 - Deletions: list with rationale
 - Additions: list with source
+- Promoted in: list of topic-file sections that moved up to CLAUDE.md (if any)
 - Invariants preserved: top 3-5 quoted verbatim so the user can verify they survived
-- Backup: `CLAUDE.md.bak` was created in Phase 6 step 1 — diff with `diff CLAUDE.md.bak CLAUDE.md` then remove
+
+**Topic files created** — for each: path, line count, seeded-from source
+
+**Topic files updated** — for each: path, `<before> → <after>` lines, one-line change summary (e.g. "2 stale paths corrected, 1 section promoted to CLAUDE.md, 1 new section added from Agent C2 findings"). Flag any topic file over the ~300-line informational ceiling.
+
+**Topic files unchanged** — bare list (no drift detected).
+
+**Index reconciliation** — dangling references resolved, orphan topic files resolved or linked.
+
+**Backup**: `CLAUDE.md.bak` was created in Phase 6 step 1. Tell the user they can diff with `diff CLAUDE.md.bak CLAUDE.md` and remove it themselves once satisfied — the skill does not delete the backup.
 
 Exit condition: report delivered, advise user to remove `CLAUDE.md.bak` after review.

--- a/plugins/claude-coding/skills/update-claudemd/SKILL.md
+++ b/plugins/claude-coding/skills/update-claudemd/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: update-claudemd
 description: >
-  This skill should be used when the user asks to update, refresh, optimize, or
-  clean up CLAUDE.md, or when documentation is stale, verbose, or out of sync
-  with codebase reality. Triggers on "update CLAUDE.md", "refresh the docs",
-  "sync CLAUDE.md with the codebase", "optimize project instructions",
-  "clean up CLAUDE.md", "improve CLAUDE.md", "fix CLAUDE.md".
+  This skill should be used when the user says "update CLAUDE.md", "refresh
+  the docs", "sync CLAUDE.md with the codebase", "optimize project
+  instructions", "clean up CLAUDE.md", "improve CLAUDE.md", "fix CLAUDE.md",
+  "reorganize CLAUDE.md", "CLAUDE.md is too long", "extract topics from
+  CLAUDE.md", "CLAUDE.md progressive disclosure", or when CLAUDE.md is stale,
+  verbose, or out of sync.
 allowed-tools:
   - Read
   - Glob
@@ -13,6 +14,10 @@ allowed-tools:
   - Edit
   - Write
   - Bash(wc:*)
+  - Bash(git:*)
+  - Bash(ls:*)
+  - Bash(mkdir:*)
+  - Task
   - AskUserQuestion
 hooks:
   PreToolUse:
@@ -23,42 +28,144 @@ hooks:
 
 # Update and Optimize CLAUDE.md
 
-## Principles
+Reconcile project CLAUDE.md against codebase reality and git history since its last commit. Enforce progressive disclosure: CLAUDE.md is a top-level index of project identity, universal invariants, and pointers to topic files at `.claude/claudemd-topics/*.md`. Scope: project CLAUDE.md (L1) only. User-global `~/.claude/CLAUDE.md` (L0) is out of scope unless the user explicitly asks.
 
-Content in CLAUDE.md is justified only if it changes how Claude acts in the next session. Apply this test to every line — remove anything that does not influence behavior. Aim for 150-250 lines; favor patterns and principles over verbose documentation.
+## Governing Principle
 
-## Step 1: Read Current State and Explore Codebase
+Content in CLAUDE.md is justified only if it changes how Claude acts in the next session AND is needed across most tasks — not subsystem-specific. Every line resolves to one of four actions:
 
-If no `CLAUDE.md` exists, inform the user and begin from scratch using codebase exploration only. Otherwise, read the existing `CLAUDE.md` and note its line count, section structure, and any content that looks stale or duplicated. Then explore the project systematically: read configuration files (package.json, Cargo.toml, requirements.txt, etc.), map the directory structure, identify the tech stack, and note established patterns and conventions. Focus on what would change how a future Claude session works in this codebase.
+- **Keep in CLAUDE.md** — project identity, top 3-5 universal invariants, pointers to topic files
+- **Demote to `.claude/claudemd-topics/<topic>.md`** — subsystem-scoped, conditional, or detailed content that still matters
+- **Delete** — anything derivable from reading `package.json`, `ls`, or one source file
+- **Add** — new content surfaced by research that belongs in L1 or a topic file
 
-Stop exploration when the major directories, tech stack, and 3-5 key patterns are identified — patterns that affect how code should be written, tested, or deployed in this project. Do not attempt exhaustive coverage.
+## Budget
 
-## Step 2: Reconcile and Optimize
+Soft target ~120 lines, soft ceiling 150 lines. Over-budget files are flagged, not forced — hand-maintained CLAUDE.md is respected. Line counts measured with `wc -l`.
 
-Compare codebase reality with current documentation. Apply the governing principle to every line.
+## Fan-out Rule
 
-Verify that commands, paths, dependencies, and environment variables are still accurate.
+Codebase research scales with project size and churn. Compute once in Phase 1, apply in Phase 2.
 
-The dividing line: remove content Claude would infer from reading the codebase itself; keep content that would cause errors or suboptimal behavior without explicit documentation.
+Signals:
+- `churn` — commits since last CLAUDE.md touch: `git log --since="<date>" --oneline --no-merges | wc -l`
+- `files` — tracked files: `git ls-files | wc -l`
 
-Cut: code blocks duplicating source files, verbose explanations, one-time setup troubleshooting, philosophical "why this matters" sections, anything Claude can derive from file inspection.
+N (codebase-scan shards):
+- N = 1 if `churn < 20` OR `files < 100`
+- N = 2 if `20 ≤ churn < 60` OR `100 ≤ files < 500`
+- N = 3 if `60 ≤ churn < 150` OR `500 ≤ files < 2000`
+- N = 4 if `churn ≥ 150` OR `files ≥ 2000`
 
-Keep: architecture decisions, essential development commands, coding conventions, critical gotchas, non-obvious behaviors that need documentation to prevent errors.
+Take the max of the two dimensions. Cap at 4. When N > 1, partition by top-level directory clusters (e.g. `plugins/` → shard 1; `scripts/ + tests/` → shard 2).
 
-Proceed to Step 3 when every section has been evaluated against the governing principle and all inaccurate references are corrected.
+## Phase 1 — Orient and Compute Fan-out
 
-## Step 3: Structure for Scanning
+Glob for `CLAUDE.md` at the project root. If missing, inform the user that creation is out of scope for this skill and stop.
 
-Organize into scannable sections appropriate for this project type. Common sections: project overview, development commands, architecture principles, project structure, coding conventions, and development notes. Add conditional sections (design system, database schema, environment variables) only when the project warrants them.
+Record current `CLAUDE.md` line count with `wc -l`. List `.claude/claudemd-topics/*.md` if the directory exists and record each topic file's line count.
 
-If the existing CLAUDE.md has content whose purpose is unclear, use AskUserQuestion to confirm before removing it.
+Run cheap git probes as parallel Bash calls:
 
-## Step 4: Write the Optimized Version
+- `git log -1 --format="%ai" -- CLAUDE.md` — last CLAUDE.md commit date. If CLAUDE.md has no history, fall back to `git log --reverse --format="%ai" | head -1`
+- `git log --since="<date>" --oneline --no-merges | wc -l` — churn
+- `git ls-files | wc -l` — tracked files
+- `ls -d */ 2>/dev/null | wc -l` — top-level directory count
 
-Write the updated CLAUDE.md. Ensure scannable headers, concise actionable content, accurate reflection of the current codebase, and minimal redundancy.
+Compute N using the fan-out rule. Decide the shard plan: which top-level directories each Codebase Scan agent will cover.
 
-A `CLAUDE.md.bak` backup was created automatically before this write. Inform the user it exists for diffing and suggest removing it after review.
+Exit condition: CLAUDE.md exists, baseline line counts recorded, N computed, shard plan decided.
 
-## Output Summary
+## Phase 2 — Parallel Research
 
-Summarize what changed: line count before vs after, sections added or removed, and key corrections applied.
+Launch `3 + N` Explore agents in a single message. All use `subagent_type: Explore`.
+
+**Agent A — CLAUDE.md and Topic Files Audit** (`subagent_type: Explore`)
+
+Read the project's CLAUDE.md and every file in `.claude/claudemd-topics/` if present. For each H1/H2/H3 section, record: name, line count, and classification hint (project identity, universal invariant, subsystem-scoped detail, conditional guidance, or derivable from file inspection). Flag stale content (version numbers, paths, commands, features that look wrong). Flag duplication across CLAUDE.md and topic files. Return: `sections[{name, line_count, classification_hint}]`, `stale_items`, `duplications`, `existing_topic_files[{name, line_count, subject}]`.
+
+**Agent B — Git History Since Last CLAUDE.md Touch** (`subagent_type: Explore`)
+
+Run `git log -1 --format="%ai" -- CLAUDE.md` to find the last CLAUDE.md commit date. If no history, use the initial commit date from `git log --reverse --format="%ai" | head -1`. Then run `git log --since="<that date>" --format="%s%n%b" --no-merges`. Categorize each commit: `new_subsystems` (net-new code areas), `architecture_changes` (decisions or refactors affecting how code should be written), `convention_changes` (new patterns), `removed_features` (gone from the codebase), `other`. Skip CI, formatting, version bumps. Return: `claudemd_last_updated` (ISO date), `changes_since` with the five lists.
+
+**Agents C1..CN — Codebase Scan Shards** (`subagent_type: Explore`)
+
+One agent per shard. Each shard covers the assigned top-level directories from the shard plan. Extract: tech stack and frameworks, established patterns (testing style, error handling, module organization), non-obvious conventions a new contributor would trip on, key commands from config files or scripts, gotchas from comments or subdirectory READMEs, and clusters of content subsystem-scoped enough to deserve their own topic file. Return: `tech_stack`, `patterns`, `conventions`, `commands`, `gotchas`, `topic_file_candidates[{filename, subject}]`.
+
+Exit condition: all `3 + N` agents return structured notes. If any agent returns empty or truncated, proceed with available results and note the gap in the Phase 5 proposal.
+
+## Phase 3 — Classify
+
+Assign exactly one action (`keep`, `demote → <topic-file>`, `delete`, `add`) to every existing section from Agent A and every new finding from Agents B and C1..CN.
+
+Cluster demotion candidates and topic-file candidates from codebase-scan shards by subject. Each cluster becomes one topic file with a proposed filename.
+
+The top 3-5 universal invariants are never demoted — they are the content that changes how Claude acts in almost every task in this project.
+
+Exit condition: every section and every finding has exactly one action, and demotion candidates are grouped into named topic-file clusters.
+
+## Phase 4 — Budget Check
+
+Estimate the post-reconciliation CLAUDE.md line count: `current + added − demoted − deleted`.
+
+If the estimate is ≤ 150, stop demoting. Having topic files does not justify over-demotion.
+
+If the estimate is > 150, demote additional lowest-priority `keep` items by cluster until under 150. Top invariants are off-limits. If the file still exceeds 150 after reasonable demotion — typically because it is hand-maintained with intentional density — flag the overage in Phase 5 and let the user decide whether to accept it.
+
+Exit condition: final action list exists with pre/post line count estimate and a budget status: `under`, `over (user override)`.
+
+## Phase 5 — Propose
+
+Present the plan in a structured summary:
+
+- Line count: `<current> → <estimated>` (budget: `<status>`)
+- Keep: count of sections
+- Delete: list with one-line rationale each (e.g. "derivable from `package.json`")
+- Demote: grouped by target topic file, showing which sections go to each
+- Add: list of new content with source (which research agent found it)
+- Topic files to create: list with filenames and line estimates
+- Topic files to update: list
+- Topic files to leave alone: list
+
+Use AskUserQuestion with three options: approve all, approve selectively, reject.
+
+Exit condition: user has explicitly approved an action set.
+
+## Phase 6 — Write
+
+The PreToolUse hook handles `CLAUDE.md.bak` automatically. Execute in this order so topic-file pointers resolve:
+
+1. Create `.claude/claudemd-topics/` with `mkdir -p` if missing
+2. Write or edit topic files
+3. Write CLAUDE.md with a regenerated `## Topic Files` section at the end
+
+The `## Topic Files` section is regenerated from actual disk state after step 2, not maintained manually. Each entry is a load trigger, not a descriptive link:
+
+```
+## Topic Files
+
+Read on demand — do not load preemptively.
+
+- `.claude/claudemd-topics/testing.md` — before writing or modifying tests
+- `.claude/claudemd-topics/hooks.md` — before editing anything in plugins/*/hooks/
+```
+
+The load-trigger phrase is generated from the topic file's subject, not copied from a heading.
+
+Use `Edit` for targeted changes when most of CLAUDE.md is staying. Use `Write` only if more than 60% of the file is changing — at that point the document is being regenerated rather than updated.
+
+Exit condition: all files written, `## Topic Files` section reflects actual disk state.
+
+## Phase 7 — Report
+
+Output a diff summary:
+
+- CLAUDE.md: `<before> → <after>` lines (`<budget status>`)
+- Topic files created: list with line counts
+- Topic files updated: list
+- Deletions: list with rationale
+- Additions: list with source
+- Invariants preserved: top 3-5 quoted verbatim so the user can verify they survived
+- Backup: `CLAUDE.md.bak` exists for diffing; remove after review
+
+Exit condition: report delivered, `CLAUDE.md.bak` cleanup advised.

--- a/plugins/claude-coding/skills/update-claudemd/SKILL.md
+++ b/plugins/claude-coding/skills/update-claudemd/SKILL.md
@@ -48,12 +48,15 @@ Signals:
 - `files` — tracked files: `git ls-files | wc -l`
 
 N (codebase-scan shards):
-- N = 1 if `churn < 20` OR `files < 100`
-- N = 2 if `20 ≤ churn < 60` OR `100 ≤ files < 500`
-- N = 3 if `60 ≤ churn < 150` OR `500 ≤ files < 2000`
-- N = 4 if `churn ≥ 150` OR `files ≥ 2000`
 
-Take the max of the two dimensions. Cap at 4. When N > 1, partition by top-level directory clusters (e.g. `plugins/` → shard 1; `scripts/ + tests/` → shard 2).
+| churn      | files         | N |
+|------------|---------------|---|
+| < 20       | < 100         | 1 |
+| 20 – 59    | 100 – 499     | 2 |
+| 60 – 149   | 500 – 1999    | 3 |
+| ≥ 150      | ≥ 2000        | 4 |
+
+Compute N for each column independently. Take the max. Cap at 4. When N > 1, partition by top-level directory clusters (e.g. `plugins/` → shard 1; `scripts/ + tests/` → shard 2).
 
 ## Phase 1 — Orient and Compute Fan-out
 
@@ -61,12 +64,17 @@ Glob for `CLAUDE.md` at the project root. If missing, inform the user that creat
 
 Record current `CLAUDE.md` line count with `wc -l`. List `.claude/claudemd-topics/*.md` if the directory exists and record each topic file's line count.
 
-Run cheap git probes as parallel Bash calls:
+Run cheap git probes in two steps.
 
-- `git log -1 --format="%ai" -- CLAUDE.md` — last CLAUDE.md commit date. If CLAUDE.md has no history, fall back to `git log --reverse --format="%ai" | head -1`
-- `git log --since="<date>" --oneline --no-merges | wc -l` — churn
+First, resolve the last CLAUDE.md commit date (sequential — downstream probe depends on it):
+
+- `git log -1 --format="%ai" -- CLAUDE.md` → record as `<last_claudemd_date>`. If CLAUDE.md has no history, fall back to `git log --reverse --format="%ai" | head -1`.
+
+Then run the remaining probes as parallel Bash calls:
+
+- `git log --since="<last_claudemd_date>" --oneline --no-merges | wc -l` — churn
 - `git ls-files | wc -l` — tracked files
-- `ls -d */ 2>/dev/null | wc -l` — top-level directory count
+- `git ls-files | awk -F/ 'NF>1{print $1}' | sort -u | wc -l` — top-level directory count
 
 Compute N using the fan-out rule. Decide the shard plan: which top-level directories each Codebase Scan agent will cover.
 


### PR DESCRIPTION
## Summary

Replaces the 4-step linear flow of `update-claudemd` with a 7-phase workflow that
treats CLAUDE.md as a top-level index pointing at `.claude/claudemd-topics/*.md`
topic files. Cuts to CLAUDE.md become demotions rather than knowledge loss, and
codebase research scales adaptively to repo size and churn.

### What changed in behavior

- **Four-way classification** (`keep` / `demote` / `delete` / `add`) replaces the
  old delete-or-keep binary. Subsystem-scoped content moves to topic files instead
  of being cut.
- **Soft 120/150-line budget** for CLAUDE.md, with a user override for
  hand-maintained files that legitimately need more density.
- **Adaptive parallel research**: Phase 2 spawns `3 + N` Explore agents in a
  single message — Agent A audits CLAUDE.md and existing topic files, Agent B
  walks git history since the last CLAUDE.md commit, and N Codebase Scan shards
  partition the repo by top-level directory cluster. N is computed from churn and
  tracked file count, capped at 4. The fan-out rule is stated explicitly so two
  Claude instances compute the same N on the same repo.
- **Topic file pointers use load-trigger phrasing** ("read before writing tests")
  rather than descriptive links, so Claude knows when to load each file rather
  than reading it defensively every session.
- **`## Topic Files` section is regenerated from disk state** in Phase 6, making
  the skill idempotent across runs — re-running the skill on a repo that already
  has topic files won't cause drift.

### Breaking changes

- **Creation scope removed.** The skill no longer bootstraps new CLAUDE.md files.
  If Phase 1 finds no CLAUDE.md at the project root, it now informs the user
  that creation is out of scope and stops. Projects without a CLAUDE.md must
  create one manually (or use a template) before invoking the skill. This is a
  behavioral regression from the prior version and is intentional — the new
  workflow assumes a baseline to reconcile against.

### Preserved from the old skill

- The explicit `cp CLAUDE.md CLAUDE.md.bak` backup step at the start of Phase 6
  (the prior version used a `PreToolUse` hook in frontmatter, which was
  silently dropped by the skill loader; that fake hook was replaced with an
  explicit Bash step in commit 35b0c5a)
- The governing principle that content must change how Claude acts in the next
  session
- The delete-if-derivable rule

### Skill body

170 → 171 lines (was 65). Validator passes; skill-lint auto-applied a description
de-duplication (~114 → ~85 tokens) and minor scannability fixes (per-agent
`subagent_type` annotations, Phase 7 exit condition).

### Review feedback addressed

- Fan-out rule OR/max contradiction → replaced with two-column table + single
  "compute per column, take max" instruction (a200a44)
- Phase 1 probe dependency (churn probe depended on date probe output) →
  restructured into sequential date resolution + three parallel probes (a200a44)
- `ls -d */` shell-fragile dir count → replaced with portable
  `git ls-files | awk` variant (a200a44)
- CLAUDE.md bare-filename reference → clarified with in-file cross-reference (5a0d778)

## Test plan

- [ ] Run `update-claudemd` against a repo with no `.claude/claudemd-topics/`
      directory and a small CLAUDE.md (under budget) — confirm the skill skips
      demotion and only reconciles drift
- [ ] Run against a repo with CLAUDE.md over 150 lines — confirm Phase 4 proposes
      demotions to topic files and respects the top 3-5 invariants
- [ ] Run twice in succession on the same repo — confirm idempotency (no
      thrashing of the `## Topic Files` section)
- [ ] Run on a large repo (`git ls-files | wc -l > 2000`) — confirm N = 4 and
      shard plan partitions top-level directories sensibly
- [ ] Run on a repo with no CLAUDE.md — confirm the skill stops gracefully and
      reports creation is out of scope