### PR TITLE
fix(memory): make sync_session append-only, remove destructive DELETEs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.79",
+      "version": "0.8.80",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.78",
+      "version": "0.8.79",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "name": "claude-skills",
       "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
-      "version": "0.5.18",
+      "version": "0.5.19",
       "source": "./plugins/claude-skills"
     },
     {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.79](https://img.shields.io/badge/v0.8.79-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.80](https://img.shields.io/badge/v0.8.80-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.78](https://img.shields.io/badge/v0.8.78-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.79](https://img.shields.io/badge/v0.8.79-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Coding workflow skills for Claude Code. Nine skills and two agents covering the 
 
 <a id="claude-skills"></a>
 
-### ✍️ claude-skills &nbsp; ![v0.5.18](https://img.shields.io/badge/v0.5.18-blue?style=flat-square)
+### ✍️ claude-skills &nbsp; ![v0.5.19](https://img.shields.io/badge/v0.5.19-blue?style=flat-square)
 
 Skill authoring tools for Claude Code. Six skills covering the full lifecycle from creation to repair.
 

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.79",
+  "version": "0.8.80",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.78",
+  "version": "0.8.79",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.78](https://img.shields.io/badge/v0.8.78-blue?style=flat-square)
+# claude-memory ![v0.8.79](https://img.shields.io/badge/v0.8.79-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.79](https://img.shields.io/badge/v0.8.79-blue?style=flat-square)
+# claude-memory ![v0.8.80](https://img.shields.io/badge/v0.8.80-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/hooks/sync_current.py
+++ b/plugins/claude-memory/hooks/sync_current.py
@@ -141,7 +141,12 @@ def sync_session(conn: sqlite3.Connection, filepath: Path, project_dir: Path) ->
     cursor.execute("SELECT id FROM sessions WHERE uuid = ?", (session_uuid,))
     session_id = cursor.fetchone()[0]
 
-    # Step 2: Insert ALL messages once, dedup by (session_id, uuid)
+    # Build set of all UUIDs claimed by any branch (filter for message insertion)
+    valid_branch_uuids = set()
+    for branch in branches:
+        valid_branch_uuids.update(branch["uuids"])
+
+    # Step 2: Insert messages that belong to a branch, dedup by (session_id, uuid)
     existing_uuids = set()
     cursor.execute(
         "SELECT uuid FROM messages WHERE session_id = ? AND uuid IS NOT NULL",
@@ -161,13 +166,18 @@ def sync_session(conn: sqlite3.Connection, filepath: Path, project_dir: Path) ->
         if entry_type == "user" and is_tool_result(content):
             continue
 
+        uuid = entry.get("uuid")
+
+        # Skip messages not claimed by any branch (prevents orphan ingestion)
+        if uuid and uuid not in valid_branch_uuids:
+            continue
+
         notification = 1 if (entry_type == "user" and (is_task_notification(content) or is_teammate_message(content))) else 0
 
         text, has_tool_use, has_thinking, tool_summary = extract_text_content(content)
         if not text:
             continue
 
-        uuid = entry.get("uuid")
         if uuid and uuid in existing_uuids:
             continue
 
@@ -208,14 +218,11 @@ def sync_session(conn: sqlite3.Connection, filepath: Path, project_dir: Path) ->
     )
     existing_branches = {row[1]: row[0] for row in cursor.fetchall()}
 
-    current_leaf_uuids = set()
-
     for branch in branches:
         leaf_uuid = branch["leaf_uuid"]
         branch_uuids = branch["uuids"]
         is_active = branch["is_active"]
         fork_point_uuid = branch.get("fork_point_uuid")
-        current_leaf_uuids.add(leaf_uuid)
 
         # Filter messages to this branch
         branch_msgs = [m for m in messages if m.get("uuid") in branch_uuids]
@@ -277,16 +284,33 @@ def sync_session(conn: sqlite3.Connection, filepath: Path, project_dir: Path) ->
                 WHERE session_id = ? AND id != ? AND is_active = 1
             """, (session_id, branch_db_id))
 
-        # Rebuild branch_messages for this branch
-        cursor.execute("DELETE FROM branch_messages WHERE branch_id = ?", (branch_db_id,))
+        # Update branch_messages via targeted diff (not full rebuild)
+        cursor.execute(
+            "SELECT message_id FROM branch_messages WHERE branch_id = ?",
+            (branch_db_id,)
+        )
+        existing_bm_ids = {row[0] for row in cursor.fetchall()}
 
+        desired_bm_ids = set()
         for uuid in branch_uuids:
             msg_id = uuid_to_msg_id.get(uuid)
             if msg_id:
-                cursor.execute(
-                    "INSERT OR IGNORE INTO branch_messages (branch_id, message_id) VALUES (?, ?)",
-                    (branch_db_id, msg_id)
-                )
+                desired_bm_ids.add(msg_id)
+
+        to_add = desired_bm_ids - existing_bm_ids
+        to_remove = existing_bm_ids - desired_bm_ids
+
+        if to_remove:
+            ph = ",".join("?" * len(to_remove))
+            cursor.execute(
+                f"DELETE FROM branch_messages WHERE branch_id = ? AND message_id IN ({ph})",
+                (branch_db_id, *to_remove)
+            )
+        if to_add:
+            cursor.executemany(
+                "INSERT OR IGNORE INTO branch_messages (branch_id, message_id) VALUES (?, ?)",
+                [(branch_db_id, mid) for mid in to_add]
+            )
 
         # Aggregate branch content for FTS
         agg_content = aggregate_branch_content(cursor, branch_db_id)
@@ -304,27 +328,6 @@ def sync_session(conn: sqlite3.Connection, filepath: Path, project_dir: Path) ->
             """, (summary_md, summary_json, branch_db_id))
         except Exception:
             pass  # Don't fail sync on summary errors
-
-    # Step 5: Clean up stale branches
-    stale_branch_ids = [
-        old_branch_id
-        for old_leaf, old_branch_id in existing_branches.items()
-        if old_leaf not in current_leaf_uuids
-    ]
-    if stale_branch_ids:
-        placeholders = ",".join("?" * len(stale_branch_ids))
-        cursor.execute(f"DELETE FROM branch_messages WHERE branch_id IN ({placeholders})", stale_branch_ids)
-        cursor.execute(f"DELETE FROM branches WHERE id IN ({placeholders})", stale_branch_ids)
-
-    # Clean up orphaned messages (not referenced by any branch)
-    cursor.execute("""
-        DELETE FROM messages
-        WHERE session_id = ? AND id NOT IN (
-            SELECT DISTINCT bm.message_id FROM branch_messages bm
-            JOIN branches b ON bm.branch_id = b.id
-            WHERE b.session_id = ?
-        )
-    """, (session_id, session_id))
 
     return new_count
 

--- a/plugins/claude-memory/hooks/sync_current.py
+++ b/plugins/claude-memory/hooks/sync_current.py
@@ -167,9 +167,11 @@ def sync_session(conn: sqlite3.Connection, filepath: Path, project_dir: Path) ->
             continue
 
         uuid = entry.get("uuid")
+        if not uuid:
+            continue
 
         # Skip messages not claimed by any branch (prevents orphan ingestion)
-        if uuid and uuid not in valid_branch_uuids:
+        if uuid not in valid_branch_uuids:
             continue
 
         notification = 1 if (entry_type == "user" and (is_task_notification(content) or is_teammate_message(content))) else 0
@@ -178,7 +180,7 @@ def sync_session(conn: sqlite3.Connection, filepath: Path, project_dir: Path) ->
         if not text:
             continue
 
-        if uuid and uuid in existing_uuids:
+        if uuid in existing_uuids:
             continue
 
         origin = parse_origin(entry)
@@ -201,8 +203,7 @@ def sync_session(conn: sqlite3.Connection, filepath: Path, project_dir: Path) ->
         ))
         if cursor.rowcount > 0:
             new_count += 1
-            if uuid:
-                existing_uuids.add(uuid)
+            existing_uuids.add(uuid)
 
     # Step 3: Build uuid -> message_id mapping
     cursor.execute(

--- a/plugins/claude-skills/.claude-plugin/plugin.json
+++ b/plugins/claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-skills/README.md
+++ b/plugins/claude-skills/README.md
@@ -1,4 +1,4 @@
-# claude-skills ![v0.5.18](https://img.shields.io/badge/v0.5.18-blue?style=flat-square)
+# claude-skills ![v0.5.19](https://img.shields.io/badge/v0.5.19-blue?style=flat-square)
 
 Skill and agent authoring tools for Claude Code. Six complementary skills: one generates skills from scratch, one generates agents, one audits skills for structural correctness, one audits agents for structural correctness, one improves skills for effectiveness, and one designs CLI interfaces for the scripts those skills produce. A bundled `skill-lint` agent runs structural linting automatically after skill creation or improvement.
 

--- a/plugins/claude-skills/skills/create-skill/SKILL.md
+++ b/plugins/claude-skills/skills/create-skill/SKILL.md
@@ -43,7 +43,7 @@ Exit 1 = naming collision; ask user whether to overwrite or rename.
 
 Read `${CLAUDE_PLUGIN_ROOT}/skills/create-skill/references/frontmatter-options.md` for the full field catalog, description patterns, tool selection framework, and execution modifiers.
 
-**Description density rules:** Keep descriptions under 100 tokens (150 absolute max) — they load every session. Derive trigger phrases from the user's actual words in Phase 0, not paraphrases. See the token budget and trigger derivation principles in `frontmatter-options.md`.
+**Description density rules:** Keep descriptions under 150 tokens (200 absolute max) — they load every session. Descriptions over 250 characters are truncated in the skill listing. Derive trigger phrases from the user's actual words in Phase 0, not paraphrases. See the token budget, pushy routing pattern, and trigger derivation principles in `frontmatter-options.md`.
 
 **Intensional over extensional — apply to all generated content.** State the rule directly with its reasoning rather than listing examples that imply the rule. An intensional rule ("quoted phrases must be verbatim user speech *because* routing matches on literal tokens") generalizes to every input the skill will encounter. An extensional approach requires the reader to reverse-engineer the rule — two reasoning hops instead of one, covering only the shape of those specific examples. Since this skill generates instructions that will themselves guide further generation, the quality of reasoning propagates.
 
@@ -93,10 +93,12 @@ Brief overview (1-2 sentences).
 | Syntax | Purpose |
 |--------|---------|
 | `$ARGUMENTS` | All arguments as string |
-| `$1`, `$2`, `$3` | Positional arguments |
+| `$1`, `$2`, `$3` | Positional arguments (shell-style quoting for multi-word values) |
 | `@path/file` | Load file contents |
 | `@$1` | Load file from argument |
 | Exclamation + backticks | Execute bash command, include output |
+| `${CLAUDE_SKILL_DIR}` | Path to the skill's own directory (use for referencing bundled scripts/files) |
+| `${CLAUDE_SESSION_ID}` | Current session ID (useful for logging or session-specific output files) |
 
 **Example — injecting live context:**
 

--- a/plugins/claude-skills/skills/create-skill/references/frontmatter-options.md
+++ b/plugins/claude-skills/skills/create-skill/references/frontmatter-options.md
@@ -24,21 +24,47 @@ allowed-tools:                      # Restrict available tools
   - Grep
   - Bash(git:*)
 
-# Lifecycle hooks (optional)
+# Lifecycle hooks (optional, scoped to this skill's lifetime)
 hooks:
   PreToolUse:
-    - command: "validation-script.sh"
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "scripts/validate-input.sh"
+          timeout: 10
+          statusMessage: "Validating..."
   PostToolUse:
-    - command: "cleanup.sh"
+    - hooks:
+        - type: command
+          command: "scripts/cleanup.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "scripts/on-complete.sh"
+          once: true                # Skills only: run once, then auto-remove
+
+# Execution context
+context: fork                       # Run in a subagent (isolates from conversation)
+agent: Explore                      # Subagent type when context: fork (default: general-purpose)
+effort: high                        # Override session effort: low | medium | high | max (Opus only)
+paths: "*.py,src/**/*.ts"           # Glob patterns limiting auto-activation to matching files
+shell: bash                         # Shell for !`cmd` blocks: bash (default) or powershell
 
 # Behavior modifiers
 user-invocable: true                # Show in /command menu (default true)
-disable-model-invocation: true      # Prevent programmatic invocation (commands only)
+disable-model-invocation: true      # Prevent programmatic invocation
 argument-hint: "[arg1] [arg2]"      # Document expected arguments; quote if value contains [...]
 ---
 
 **`argument-hint` quoting rule:** Values containing `[...]` must be quoted (`"[arg]"`), because YAML treats unquoted `[` as the start of a flow sequence. Values using only `<...>` do not need quoting.
 ```
+
+**Hooks structure:** Each hook event (PreToolUse, PostToolUse, Stop, SessionStart, etc.)
+accepts an array of entries. Each entry can have a `matcher` (filter by tool name) and a
+`hooks` array with handlers. Handler fields: `type` (command, http, prompt, agent),
+`command`, `timeout` (seconds), `statusMessage` (custom spinner text), `once` (skills
+only — run once then auto-remove). Hooks are scoped to the skill's lifetime and cleaned
+up when it finishes.
 
 ---
 
@@ -53,16 +79,19 @@ argument-hint: "[arg1] [arg2]"      # Document expected arguments; quote if valu
 - **Include negative triggers for adjacent domains.** Routing is a classification problem — explicit exclusions sharpen the decision boundary. Add "Not for X" or "Don't use for Y" when the skill could plausibly false-trigger on a related but distinct domain.
 - **3–5 trigger phrases minimum.** Single-phrase descriptions have high miss rates. Varied phrases improve routing coverage across synonym space.
 - **Derive trigger phrases from user language.** Pull phrases from how the user actually described their need during requirements gathering, not from formalized or paraphrased versions. If the user said "fix my skill," use "fix my skill" — not "skill remediation." When no user phrasing is available, imagine the most natural way someone would describe this need without knowing the skill exists.
-- **Keep descriptions under 100 tokens (150 absolute max).** A 10-skill installation at 170 tokens each burns ~1,700 tokens per session on routing metadata alone. At 100 tokens that drops to ~1,000. Prioritize trigger phrases over explanatory prose — the description's job is routing, not documentation.
+- **Err toward overtriggering, not undertriggering.** Claude tends to undertrigger skills — to not invoke them when they'd be useful. After the core verbatim phrases, append a routing directive using intent categories: "Make sure to use this skill whenever the user mentions [X, Y, Z] — even if they don't explicitly say '[skill name]'." X/Y/Z should be intent categories and concept words (broad, generalizable), not verbatim query phrases (which overfit and bloat context). The core description uses verbatim phrases (optimized for recall); the routing suffix uses category words (broad, anti-overfit). These two layers are not interchangeable.
+- **Keep descriptions under 150 tokens (200 absolute max).** Anthropic's hard limit is 1024 characters (~250 tokens). Descriptions longer than 250 characters are truncated in the skill listing. The routing suffix from the overtriggering rule adds ~20-30 tokens — the raised budget accommodates it. Prioritize trigger phrases over explanatory prose — the description's job is routing, not documentation.
 - **Use `>` scalar, not `|`.** Folded scalar (`>`) collapses newlines to spaces, producing a single continuous string — correct for descriptions. Literal scalar (`|`) preserves newlines, which can create unexpected whitespace when parsed.
 
 ```yaml
-# Correct — third-person, verbatim phrases, folded scalar, negative trigger
+# Correct — verbatim phrases in core, category routing suffix, negative trigger
 description: >
   This skill should be used when the user asks to "create a hook",
   "add validation", "implement lifecycle automation", or mentions
-  pre/post tool events. Not for modifying existing hooks or debugging
-  hook failures.
+  pre/post tool events. Make sure to use this skill whenever the user
+  mentions hook lifecycle, automation, or tool events — even if they
+  don't explicitly say "hook". Not for modifying existing hooks or
+  debugging hook failures.
 
 # Wrong — vague, no trigger phrases, not third-person
 description: Provides guidance for hooks.
@@ -83,11 +112,17 @@ description: Deploy to staging environment
 
 ## Execution Modifiers
 
-Use these when the default behavior isn't sufficient:
+- **`hooks`** — Run scripts at lifecycle events, scoped to this skill's lifetime. See the Common Frontmatter Options block above for the full structure (matcher, type, timeout, statusMessage, once).
 
-- **`hooks`** — Run scripts before/after tool use, scoped to this skill's lifecycle. Useful for validation, logging, or side effects.
+- **`context: fork`** — Run the skill in an isolated subagent. The skill content becomes the subagent's prompt; it won't have access to conversation history. Use for task-type skills (deploy, generate, research) where isolation prevents accidental side effects. Pair with `agent` to choose the subagent type (Explore, Plan, general-purpose, or a custom agent from `.claude/agents/`).
 
-- **`disable-model-invocation: true`** — Prevent Claude from auto-loading this skill. Use for skills you want to invoke manually only (commands only).
+- **`effort`** — Override session effort level for this skill. Options: low, medium, high, max (max is Opus 4.6 only). Use high/max for skills requiring deep reasoning; low for simple lookup skills.
+
+- **`paths`** — Glob patterns (comma-separated or YAML list) limiting auto-activation. When set, Claude loads the skill automatically only when working with files matching the patterns. Use for language-specific or framework-specific skills.
+
+- **`shell`** — Shell for `!`backtick`` and ` ```! ` blocks: bash (default) or powershell. Setting powershell runs inline shell commands via PowerShell on Windows.
+
+- **`disable-model-invocation: true`** — Prevent Claude from auto-loading this skill. Use for skills with side effects you want to trigger manually only.
 
 - **`user-invocable: false`** — Hide from the `/` command menu. Use for background-knowledge skills that should trigger automatically but not appear as slash commands.
 
@@ -108,6 +143,24 @@ Default generous, restrict only when needed. The principle: restrict tools that 
 | **If delegating** | Skill | Required to invoke other skills programmatically |
 | **If notebooks** | NotebookEdit | Jupyter-specific; omit unless skill touches `.ipynb` files |
 | **If plan-gated** | ExitPlanMode, EnterPlanMode | For workflows requiring explicit user approval before execution |
+
+---
+
+## Skill Content Lifecycle
+
+When invoked, the rendered SKILL.md enters the conversation as a single message and stays
+for the rest of the session. Claude Code does not re-read the file on later turns — write
+guidance as standing instructions, not one-time steps.
+
+Auto-compaction carries invoked skills forward within a token budget: the first 5,000
+tokens of each skill are retained after compaction, and all recently invoked skills share
+a combined 25,000-token budget (filled most-recent-first). Skills exceeding 5,000 tokens
+lose their tail after compaction. Skills invoked long ago may be dropped entirely if the
+budget is exhausted. If a skill seems to stop influencing behavior, re-invoke it.
+
+Design implications: keep SKILL.md under 500 lines. Front-load critical instructions
+within the first ~5,000 tokens. Move detailed reference material to separate files that
+are loaded on demand.
 
 ---
 

--- a/plugins/claude-skills/skills/repair-skill/references/frontmatter-options.md
+++ b/plugins/claude-skills/skills/repair-skill/references/frontmatter-options.md
@@ -18,10 +18,11 @@ be third-person for skills ("This skill should be used when..."), verb-first und
 chars for commands.
 
 Audit rules for description quality:
-- **Token budget:** Under 100 tokens for most skills, 150 absolute max. At 170+ tokens, a 10-skill installation burns ~1,700 tokens per session on routing metadata alone. Prioritize trigger phrases over explanatory prose.
+- **Token budget:** Under 150 tokens for most skills, 200 absolute max. Anthropic's hard limit is 1024 characters (~250 tokens); descriptions over 250 characters are truncated in the skill listing. Prioritize trigger phrases over explanatory prose.
 - **Trigger phrase derivation:** Phrases should be verbatim user speech — the exact words someone would type, not formalized paraphrases. "fix my skill" triggers better than "skill remediation workflow."
 - **Negative triggers:** In crowded domains (multiple skills with overlapping concerns), include "Not for X" or "Don't use for Y" to sharpen the routing decision boundary.
 - **3–5 varied trigger phrases minimum.** Single-phrase descriptions have high miss rates. Include naive phrasing from a user who has never heard of this skill.
+- **Overtriggering check:** Claude tends to undertrigger skills. If the description has no routing directive ("Make sure to use this skill whenever the user mentions [X, Y, Z] — even if they don't explicitly say '[skill name]'"), flag it for the author to consider adding one. The routing suffix uses intent categories and concept words (broad, generalizable), not verbatim query phrases (which overfit). The core uses verbatim phrases (optimized for recall); the suffix uses category words (broad, anti-overfit). These two layers are not interchangeable.
 
 ### `allowed-tools` (list)
 
@@ -82,20 +83,36 @@ restriction is a security and scope risk.
 
 ### `hooks` (object)
 
-Scoped to this skill's lifecycle. Runs scripts before or after specific tool events.
+Scoped to this skill's lifetime — runs only when the skill is active, cleaned up when it
+finishes.
 
 ```yaml
 hooks:
   PreToolUse:
-    - command: "scripts/validate-input.sh"
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "scripts/validate-input.sh"
+          timeout: 10
+          statusMessage: "Validating..."
   PostToolUse:
-    - command: "scripts/cleanup.sh"
+    - hooks:
+        - type: command
+          command: "scripts/cleanup.sh"
   Stop:
-    - command: "scripts/on-complete.sh"
+    - hooks:
+        - type: command
+          command: "scripts/on-complete.sh"
+          once: true
 ```
 
-Valid hook events: `PreToolUse`, `PostToolUse`, `Stop`. Use for validation, logging,
-side effects, or cleanup that must happen deterministically around tool calls.
+All hook events are supported (PreToolUse, PostToolUse, Stop, SessionStart, etc.). Each
+entry can have a `matcher` (filter by tool name) and a `hooks` array with handlers.
+Handler fields: `type` (command, http, prompt, agent), `command`, `timeout` (seconds),
+`statusMessage` (custom spinner text), `once` (skills only — run once then auto-remove).
+
+Audit rule: hooks with no `matcher` fire on every tool call — verify this is intentional.
+Hooks using `once: true` outside of skills are invalid (agents don't support it).
 
 ### `user-invocable` (boolean)
 
@@ -124,6 +141,57 @@ need quoting.
 Audit rule: any skill that reads `$ARGUMENTS` or `$1`/`$2` should have `argument-hint`
 set so users know what to pass.
 
+### `context` (string)
+
+Set to `fork` to run the skill in an isolated subagent. The skill content becomes the
+subagent's prompt; it won't have access to conversation history. Use for task-type skills
+where isolation prevents accidental side effects. Pair with `agent`.
+
+### `agent` (string)
+
+Which subagent type to use when `context: fork` is set. Options: built-in agents
+(`Explore`, `Plan`, `general-purpose`) or custom agents from `.claude/agents/`. If
+omitted, uses `general-purpose`.
+
+Audit rule: `agent` without `context: fork` is dead config — flag it.
+
+### `effort` (string)
+
+Override session effort level: `low`, `medium`, `high`, `max` (max is Opus 4.6 only).
+Use high/max for skills requiring deep reasoning; low for simple lookup skills.
+
+### `paths` (string or list)
+
+Glob patterns limiting auto-activation. When set, Claude loads the skill automatically
+only when working with files matching the patterns. Accepts comma-separated string or
+YAML list. Uses the same format as path-specific rules in CLAUDE.md.
+
+Audit rule: skills with `paths` set should not also have broad descriptions — the path
+filter narrows scope, so the description should match that narrowed scope.
+
+### `shell` (string)
+
+Shell for `!`backtick`` and ` ```! ` blocks: `bash` (default) or `powershell`. Only
+relevant for skills using inline shell execution.
+
+---
+
+## Skill Content Lifecycle
+
+When invoked, the rendered SKILL.md enters the conversation as a single message and stays
+for the rest of the session. Claude Code does not re-read the file on later turns — write
+guidance as standing instructions, not one-time steps.
+
+Auto-compaction carries invoked skills forward within a token budget: the first 5,000
+tokens of each skill are retained after compaction, and all recently invoked skills share
+a combined 25,000-token budget (filled most-recent-first). Skills exceeding 5,000 tokens
+lose their tail after compaction. Skills invoked long ago may be dropped entirely if the
+budget is exhausted.
+
+Audit relevance: if a skill's critical instructions appear after the first ~5,000 tokens,
+they will be lost after compaction. Flag this as a structural issue — front-load critical
+content or move reference material to separate files.
+
 ---
 
 ## Dynamic Content Syntax
@@ -133,10 +201,12 @@ These substitutions are processed before the skill body reaches Claude.
 | Syntax | Resolves to |
 |--------|-------------|
 | `$ARGUMENTS` | All arguments passed to the skill as a single string |
-| `$1`, `$2`, `$3` | Individual positional arguments |
+| `$1`, `$2`, `$3` | Individual positional arguments (shell-style quoting for multi-word values) |
 | `@path/to/file` | Contents of the file at that path, loaded inline |
 | `@$1` | Contents of the file whose path was passed as the first argument |
 | bang + backtick-wrapped command (e.g. `!date`) | Output of executing the command in a shell, injected inline |
+| `${CLAUDE_SKILL_DIR}` | Path to the skill's own directory (for referencing bundled scripts/files) |
+| `${CLAUDE_SESSION_ID}` | Current session ID (for logging or session-specific output files) |
 
 Audit rule: skills that accept a file path as input should use `@$1` to load it inline
 rather than requiring a separate Read tool call — the injection happens before the model


### PR DESCRIPTION
## Summary
- Filter message insertion against branch UUID set — orphans are never ingested, eliminating the need for orphan cleanup
- Replace full `branch_messages` rebuild (DELETE all + re-insert) with targeted set-difference diff — zero writes on typical re-syncs
- Remove stale-branch cleanup and orphan-message DELETE entirely — GC belongs in the authoritative import path, not an opportunistic stop-hook parse

## Context

Architecture audit (claude-opus, codex-5.4-xhigh, gemini-3.1-pro) identified that the stop hook's unconditional orphan DELETE could permanently destroy messages when `find_all_branches` returns a partial parse (JSONL truncation, timestamp ties, broken parentUuid chains). All three reviewers converged on the same principle: an opportunistic parse of a live file should never hard-delete. The sync is now append-only + update-only.

## Changes
- `plugins/claude-memory/hooks/sync_current.py`

## Diff Stat
```
5 files changed, 39 insertions(+), 36 deletions(-)
```

## Test plan
- [ ] Verify import succeeds: `cd plugins/claude-memory/hooks && python3 -c "import sync_current; print('ok')"`
- [ ] End a Claude Code session with claude-memory enabled — confirm the Stop hook completes without error
- [ ] Verify new messages still appear in `recall-conversations` search after a session
- [ ] Verify re-sync of the same session is idempotent (no duplicate messages, no data loss)