### PR TITLE
feat(skills): sync frontmatter reference with official docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "name": "claude-skills",
       "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
-      "version": "0.5.21",
+      "version": "0.5.22",
       "source": "./plugins/claude-skills"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "name": "claude-skills",
       "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
-      "version": "0.5.19",
+      "version": "0.5.20",
       "source": "./plugins/claude-skills"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "name": "claude-skills",
       "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
-      "version": "0.5.18",
+      "version": "0.5.19",
       "source": "./plugins/claude-skills"
     },
     {

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Coding workflow skills for Claude Code. Nine skills and two agents covering the 
 
 <a id="claude-skills"></a>
 
-### ✍️ claude-skills &nbsp; ![v0.5.18](https://img.shields.io/badge/v0.5.18-blue?style=flat-square)
+### ✍️ claude-skills &nbsp; ![v0.5.19](https://img.shields.io/badge/v0.5.19-blue?style=flat-square)
 
 Skill authoring tools for Claude Code. Six skills covering the full lifecycle from creation to repair.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Coding workflow skills for Claude Code. Nine skills and two agents covering the 
 
 <a id="claude-skills"></a>
 
-### ✍️ claude-skills &nbsp; ![v0.5.19](https://img.shields.io/badge/v0.5.19-blue?style=flat-square)
+### ✍️ claude-skills &nbsp; ![v0.5.20](https://img.shields.io/badge/v0.5.20-blue?style=flat-square)
 
 Skill authoring tools for Claude Code. Six skills covering the full lifecycle from creation to repair.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Coding workflow skills for Claude Code. Nine skills and two agents covering the 
 
 <a id="claude-skills"></a>
 
-### ✍️ claude-skills &nbsp; ![v0.5.21](https://img.shields.io/badge/v0.5.21-blue?style=flat-square)
+### ✍️ claude-skills &nbsp; ![v0.5.22](https://img.shields.io/badge/v0.5.22-blue?style=flat-square)
 
 Skill authoring tools for Claude Code. Six skills covering the full lifecycle from creation to repair.
 

--- a/plugins/claude-skills/.claude-plugin/plugin.json
+++ b/plugins/claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-skills/.claude-plugin/plugin.json
+++ b/plugins/claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-skills/.claude-plugin/plugin.json
+++ b/plugins/claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-skills/README.md
+++ b/plugins/claude-skills/README.md
@@ -1,4 +1,4 @@
-# claude-skills ![v0.5.19](https://img.shields.io/badge/v0.5.19-blue?style=flat-square)
+# claude-skills ![v0.5.20](https://img.shields.io/badge/v0.5.20-blue?style=flat-square)
 
 Skill and agent authoring tools for Claude Code. Six complementary skills: one generates skills from scratch, one generates agents, one audits skills for structural correctness, one audits agents for structural correctness, one improves skills for effectiveness, and one designs CLI interfaces for the scripts those skills produce. A bundled `skill-lint` agent runs structural linting automatically after skill creation or improvement.
 

--- a/plugins/claude-skills/README.md
+++ b/plugins/claude-skills/README.md
@@ -1,4 +1,4 @@
-# claude-skills ![v0.5.18](https://img.shields.io/badge/v0.5.18-blue?style=flat-square)
+# claude-skills ![v0.5.19](https://img.shields.io/badge/v0.5.19-blue?style=flat-square)
 
 Skill and agent authoring tools for Claude Code. Six complementary skills: one generates skills from scratch, one generates agents, one audits skills for structural correctness, one audits agents for structural correctness, one improves skills for effectiveness, and one designs CLI interfaces for the scripts those skills produce. A bundled `skill-lint` agent runs structural linting automatically after skill creation or improvement.
 

--- a/plugins/claude-skills/README.md
+++ b/plugins/claude-skills/README.md
@@ -1,4 +1,4 @@
-# claude-skills ![v0.5.21](https://img.shields.io/badge/v0.5.21-blue?style=flat-square)
+# claude-skills ![v0.5.22](https://img.shields.io/badge/v0.5.22-blue?style=flat-square)
 
 Skill and agent authoring tools for Claude Code. Six complementary skills: one generates skills from scratch, one generates agents, one audits skills for structural correctness, one audits agents for structural correctness, one improves skills for effectiveness, and one designs CLI interfaces for the scripts those skills produce. A bundled `skill-lint` agent runs structural linting automatically after skill creation or improvement.
 

--- a/plugins/claude-skills/skills/create-skill/SKILL.md
+++ b/plugins/claude-skills/skills/create-skill/SKILL.md
@@ -43,7 +43,7 @@ Exit 1 = naming collision; ask user whether to overwrite or rename.
 
 Read `${CLAUDE_PLUGIN_ROOT}/skills/create-skill/references/frontmatter-options.md` for the full field catalog, description patterns, tool selection framework, and execution modifiers.
 
-**Description density rules:** Keep descriptions under 100 tokens (150 absolute max) — they load every session. Derive trigger phrases from the user's actual words in Phase 0, not paraphrases. See the token budget and trigger derivation principles in `frontmatter-options.md`.
+**Description density rules:** Keep descriptions under 150 tokens (200 absolute max) — they load every session. Descriptions over 250 characters are truncated in the skill listing. Derive trigger phrases from the user's actual words in Phase 0, not paraphrases. See the token budget, pushy routing pattern, and trigger derivation principles in `frontmatter-options.md`.
 
 **Intensional over extensional — apply to all generated content.** State the rule directly with its reasoning rather than listing examples that imply the rule. An intensional rule ("quoted phrases must be verbatim user speech *because* routing matches on literal tokens") generalizes to every input the skill will encounter. An extensional approach requires the reader to reverse-engineer the rule — two reasoning hops instead of one, covering only the shape of those specific examples. Since this skill generates instructions that will themselves guide further generation, the quality of reasoning propagates.
 
@@ -93,10 +93,12 @@ Brief overview (1-2 sentences).
 | Syntax | Purpose |
 |--------|---------|
 | `$ARGUMENTS` | All arguments as string |
-| `$1`, `$2`, `$3` | Positional arguments |
+| `$1`, `$2`, `$3` | Positional arguments (shell-style quoting for multi-word values) |
 | `@path/file` | Load file contents |
 | `@$1` | Load file from argument |
 | Exclamation + backticks | Execute bash command, include output |
+| `${CLAUDE_SKILL_DIR}` | Path to the skill's own directory (use for referencing bundled scripts/files) |
+| `${CLAUDE_SESSION_ID}` | Current session ID (useful for logging or session-specific output files) |
 
 **Example — injecting live context:**
 

--- a/plugins/claude-skills/skills/create-skill/SKILL.md
+++ b/plugins/claude-skills/skills/create-skill/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: create-skill
 description: >
-  This skill should be used when the user asks to "create a skill", "make a command",
-  "write a slash command", "build a Claude extension", or "add a skill to a plugin".
+  This skill should be used when the user asks to "create a skill" or "make a command".
+  Make sure to use this skill whenever the user mentions skill creation, command authoring,
+  slash commands, or building Claude extensions — even if they don't explicitly say
+  "create-skill". Not for repairing or auditing existing skills — use repair-skill.
 argument-hint: "[skill|command] [name] - or leave empty to interview"
 ---
 # Skill & Command Generator

--- a/plugins/claude-skills/skills/create-skill/references/frontmatter-options.md
+++ b/plugins/claude-skills/skills/create-skill/references/frontmatter-options.md
@@ -24,21 +24,47 @@ allowed-tools:                      # Restrict available tools
   - Grep
   - Bash(git:*)
 
-# Lifecycle hooks (optional)
+# Lifecycle hooks (optional, scoped to this skill's lifetime)
 hooks:
   PreToolUse:
-    - command: "validation-script.sh"
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "scripts/validate-input.sh"
+          timeout: 10
+          statusMessage: "Validating..."
   PostToolUse:
-    - command: "cleanup.sh"
+    - hooks:
+        - type: command
+          command: "scripts/cleanup.sh"
+  Stop:
+    - hooks:
+        - type: command
+          command: "scripts/on-complete.sh"
+          once: true                # Skills only: run once, then auto-remove
+
+# Execution context
+context: fork                       # Run in a subagent (isolates from conversation)
+agent: Explore                      # Subagent type when context: fork (default: general-purpose)
+effort: high                        # Override session effort: low | medium | high | max (Opus only)
+paths: "*.py,src/**/*.ts"           # Glob patterns limiting auto-activation to matching files
+shell: bash                         # Shell for !`cmd` blocks: bash (default) or powershell
 
 # Behavior modifiers
 user-invocable: true                # Show in /command menu (default true)
-disable-model-invocation: true      # Prevent programmatic invocation (commands only)
+disable-model-invocation: true      # Prevent programmatic invocation
 argument-hint: "[arg1] [arg2]"      # Document expected arguments; quote if value contains [...]
 ---
 
 **`argument-hint` quoting rule:** Values containing `[...]` must be quoted (`"[arg]"`), because YAML treats unquoted `[` as the start of a flow sequence. Values using only `<...>` do not need quoting.
 ```
+
+**Hooks structure:** Each hook event (PreToolUse, PostToolUse, Stop, SessionStart, etc.)
+accepts an array of entries. Each entry can have a `matcher` (filter by tool name) and a
+`hooks` array with handlers. Handler fields: `type` (command, http, prompt, agent),
+`command`, `timeout` (seconds), `statusMessage` (custom spinner text), `once` (skills
+only — run once then auto-remove). Hooks are scoped to the skill's lifetime and cleaned
+up when it finishes.
 
 ---
 
@@ -53,16 +79,19 @@ argument-hint: "[arg1] [arg2]"      # Document expected arguments; quote if valu
 - **Include negative triggers for adjacent domains.** Routing is a classification problem — explicit exclusions sharpen the decision boundary. Add "Not for X" or "Don't use for Y" when the skill could plausibly false-trigger on a related but distinct domain.
 - **3–5 trigger phrases minimum.** Single-phrase descriptions have high miss rates. Varied phrases improve routing coverage across synonym space.
 - **Derive trigger phrases from user language.** Pull phrases from how the user actually described their need during requirements gathering, not from formalized or paraphrased versions. If the user said "fix my skill," use "fix my skill" — not "skill remediation." When no user phrasing is available, imagine the most natural way someone would describe this need without knowing the skill exists.
-- **Keep descriptions under 100 tokens (150 absolute max).** A 10-skill installation at 170 tokens each burns ~1,700 tokens per session on routing metadata alone. At 100 tokens that drops to ~1,000. Prioritize trigger phrases over explanatory prose — the description's job is routing, not documentation.
+- **Err toward overtriggering, not undertriggering.** Claude tends to undertrigger skills — to not invoke them when they'd be useful. After the core verbatim phrases, append a routing directive using intent categories: "Make sure to use this skill whenever the user mentions [X, Y, Z] — even if they don't explicitly say '[skill name]'." X/Y/Z should be intent categories and concept words (broad, generalizable), not verbatim query phrases (which overfit and bloat context). The core description uses verbatim phrases (optimized for recall); the routing suffix uses category words (broad, anti-overfit). These two layers are not interchangeable.
+- **Keep descriptions under 150 tokens (200 absolute max).** Anthropic's hard limit is 1024 characters (~250 tokens). Descriptions longer than 250 characters are truncated in the skill listing. The routing suffix from the overtriggering rule adds ~20-30 tokens — the raised budget accommodates it. Prioritize trigger phrases over explanatory prose — the description's job is routing, not documentation.
 - **Use `>` scalar, not `|`.** Folded scalar (`>`) collapses newlines to spaces, producing a single continuous string — correct for descriptions. Literal scalar (`|`) preserves newlines, which can create unexpected whitespace when parsed.
 
 ```yaml
-# Correct — third-person, verbatim phrases, folded scalar, negative trigger
+# Correct — verbatim phrases in core, category routing suffix, negative trigger
 description: >
   This skill should be used when the user asks to "create a hook",
   "add validation", "implement lifecycle automation", or mentions
-  pre/post tool events. Not for modifying existing hooks or debugging
-  hook failures.
+  pre/post tool events. Make sure to use this skill whenever the user
+  mentions hook lifecycle, automation, or tool events — even if they
+  don't explicitly say "hook". Not for modifying existing hooks or
+  debugging hook failures.
 
 # Wrong — vague, no trigger phrases, not third-person
 description: Provides guidance for hooks.
@@ -83,11 +112,17 @@ description: Deploy to staging environment
 
 ## Execution Modifiers
 
-Use these when the default behavior isn't sufficient:
+- **`hooks`** — Run scripts at lifecycle events, scoped to this skill's lifetime. See the Common Frontmatter Options block above for the full structure (matcher, type, timeout, statusMessage, once).
 
-- **`hooks`** — Run scripts before/after tool use, scoped to this skill's lifecycle. Useful for validation, logging, or side effects.
+- **`context: fork`** — Run the skill in an isolated subagent. The skill content becomes the subagent's prompt; it won't have access to conversation history. Use for task-type skills (deploy, generate, research) where isolation prevents accidental side effects. Pair with `agent` to choose the subagent type (Explore, Plan, general-purpose, or a custom agent from `.claude/agents/`).
 
-- **`disable-model-invocation: true`** — Prevent Claude from auto-loading this skill. Use for skills you want to invoke manually only (commands only).
+- **`effort`** — Override session effort level for this skill. Options: low, medium, high, max (max is Opus 4.6 only). Use high/max for skills requiring deep reasoning; low for simple lookup skills.
+
+- **`paths`** — Glob patterns (comma-separated or YAML list) limiting auto-activation. When set, Claude loads the skill automatically only when working with files matching the patterns. Use for language-specific or framework-specific skills.
+
+- **`shell`** — Shell for `!`backtick`` and ` ```! ` blocks: bash (default) or powershell. Setting powershell runs inline shell commands via PowerShell on Windows.
+
+- **`disable-model-invocation: true`** — Prevent Claude from auto-loading this skill. Use for skills with side effects you want to trigger manually only.
 
 - **`user-invocable: false`** — Hide from the `/` command menu. Use for background-knowledge skills that should trigger automatically but not appear as slash commands.
 
@@ -108,6 +143,24 @@ Default generous, restrict only when needed. The principle: restrict tools that 
 | **If delegating** | Skill | Required to invoke other skills programmatically |
 | **If notebooks** | NotebookEdit | Jupyter-specific; omit unless skill touches `.ipynb` files |
 | **If plan-gated** | ExitPlanMode, EnterPlanMode | For workflows requiring explicit user approval before execution |
+
+---
+
+## Skill Content Lifecycle
+
+When invoked, the rendered SKILL.md enters the conversation as a single message and stays
+for the rest of the session. Claude Code does not re-read the file on later turns — write
+guidance as standing instructions, not one-time steps.
+
+Auto-compaction carries invoked skills forward within a token budget: the first 5,000
+tokens of each skill are retained after compaction, and all recently invoked skills share
+a combined 25,000-token budget (filled most-recent-first). Skills exceeding 5,000 tokens
+lose their tail after compaction. Skills invoked long ago may be dropped entirely if the
+budget is exhausted. If a skill seems to stop influencing behavior, re-invoke it.
+
+Design implications: keep SKILL.md under 500 lines. Front-load critical instructions
+within the first ~5,000 tokens. Move detailed reference material to separate files that
+are loaded on demand.
 
 ---
 

--- a/plugins/claude-skills/skills/create-skill/references/frontmatter-options.md
+++ b/plugins/claude-skills/skills/create-skill/references/frontmatter-options.md
@@ -10,21 +10,32 @@ disclosure patterns.
 
 ---
 
-## Common Frontmatter Options
+## Essential Frontmatter
+
+Every skill needs these fields. Start here.
 
 ```yaml
 ---
-name: identifier                    # Required for skills
-description: >                      # How it's described/triggered
+name: identifier                    # Required — unique skill identifier
+description: >                      # How it's described/triggered (see patterns below)
   [See description patterns below]
-
-# Tool access
-allowed-tools:                      # Restrict available tools
+allowed-tools:                      # Restrict available tools (see Tool Selection below)
   - Read
   - Grep
   - Bash(git:*)
+user-invocable: true                # Show in /command menu (default true)
+argument-hint: "[arg1] [arg2]"      # Document expected arguments; quote if value contains [...]
+---
+```
 
-# Lifecycle hooks (optional, scoped to this skill's lifetime)
+**`argument-hint` quoting rule:** Values containing `[...]` must be quoted (`"[arg]"`), because YAML treats unquoted `[` as the start of a flow sequence. Values using only `<...>` do not need quoting.
+
+## Advanced Frontmatter
+
+Use when needed — most skills don't require these.
+
+```yaml
+# Lifecycle hooks (scoped to this skill's lifetime)
 hooks:
   PreToolUse:
     - matcher: "Bash"
@@ -46,17 +57,12 @@ hooks:
 # Execution context
 context: fork                       # Run in a subagent (isolates from conversation)
 agent: Explore                      # Subagent type when context: fork (default: general-purpose)
-effort: high                        # Override session effort: low | medium | high | max (Opus only)
+effort: high                        # Override session effort: low | medium | high | max (max: Opus 4.6 only)
 paths: "*.py,src/**/*.ts"           # Glob patterns limiting auto-activation to matching files
 shell: bash                         # Shell for !`cmd` blocks: bash (default) or powershell
 
-# Behavior modifiers
-user-invocable: true                # Show in /command menu (default true)
-disable-model-invocation: true      # Prevent programmatic invocation
-argument-hint: "[arg1] [arg2]"      # Document expected arguments; quote if value contains [...]
----
-
-**`argument-hint` quoting rule:** Values containing `[...]` must be quoted (`"[arg]"`), because YAML treats unquoted `[` as the start of a flow sequence. Values using only `<...>` do not need quoting.
+# Behavior modifiers (commands)
+disable-model-invocation: true      # Prevent programmatic invocation (commands only)
 ```
 
 **Hooks structure:** Each hook event (PreToolUse, PostToolUse, Stop, SessionStart, etc.)
@@ -70,28 +76,38 @@ up when it finishes.
 
 ## Description Patterns
 
-### For Skills (auto-triggered) — principles
+### For Skills (auto-triggered) — the two-layer model
 
-- **Third-person framing is a routing signal, not a stylistic choice.** The routing model evaluates the description as a triggering condition. First-person ("Use this skill when...") reads as an instruction to execute. Third-person ("This skill should be used when...") reads as a condition to test. The framing changes how the model interprets the field.
-- **Quoted phrases must be verbatim user speech.** Routing matches on literal token patterns. Write the exact words a user would type, not paraphrases: `"create a hook"` triggers correctly; `"hook creation workflows"` may not.
-- **The description is always in context, even when the skill isn't active.** Every session pays the token cost of every skill's description. Density matters: cover more trigger patterns in fewer words. Avoid restating the skill name or explaining what skills are.
-- **Cover the naive phrasing.** A user who doesn't know this skill exists won't search for it by name — they'll describe their problem in plain language. Include the phrasing someone would use who has never heard of this skill.
-- **Include negative triggers for adjacent domains.** Routing is a classification problem — explicit exclusions sharpen the decision boundary. Add "Not for X" or "Don't use for Y" when the skill could plausibly false-trigger on a related but distinct domain.
-- **3–5 trigger phrases minimum.** Single-phrase descriptions have high miss rates. Varied phrases improve routing coverage across synonym space.
-- **Derive trigger phrases from user language.** Pull phrases from how the user actually described their need during requirements gathering, not from formalized or paraphrased versions. If the user said "fix my skill," use "fix my skill" — not "skill remediation." When no user phrasing is available, imagine the most natural way someone would describe this need without knowing the skill exists.
-- **Err toward overtriggering, not undertriggering.** Claude tends to undertrigger skills — to not invoke them when they'd be useful. After the core verbatim phrases, append a routing directive using intent categories: "Make sure to use this skill whenever the user mentions [X, Y, Z] — even if they don't explicitly say '[skill name]'." X/Y/Z should be intent categories and concept words (broad, generalizable), not verbatim query phrases (which overfit and bloat context). The core description uses verbatim phrases (optimized for recall); the routing suffix uses category words (broad, anti-overfit). These two layers are not interchangeable.
-- **Keep descriptions under 150 tokens (200 absolute max).** Anthropic's hard limit is 1024 characters (~250 tokens). Descriptions longer than 250 characters are truncated in the skill listing. The routing suffix from the overtriggering rule adds ~20-30 tokens — the raised budget accommodates it. Prioritize trigger phrases over explanatory prose — the description's job is routing, not documentation.
-- **Use `>` scalar, not `|`.** Folded scalar (`>`) collapses newlines to spaces, producing a single continuous string — correct for descriptions. Literal scalar (`|`) preserves newlines, which can create unexpected whitespace when parsed.
+Skill descriptions serve one purpose: helping the routing model decide when to trigger. They use a two-layer structure where a broad routing directive provides primary coverage and a few verbatim phrases anchor the intent.
+
+**Layer 1: Routing directive (primary coverage).** A sentence at the end that tells the model to trigger broadly across an intent category. Format: "Make sure to use this skill whenever the user mentions [X, Y, Z] — even if they don't explicitly say '[skill name]'." X/Y/Z are intent categories and concept words (broad, generalizable), not verbatim query phrases. This is the main coverage mechanism — it catches the long tail of phrasings you can't anticipate.
+
+**Layer 2: Verbatim anchors (precision).** 2–3 quoted phrases representing the exact words a user would type. These provide high-confidence matches for common cases. Derive them from real user language, not formalized paraphrases: `"fix my skill"` not `"skill remediation"`. Cover the naive phrasing — what someone would say who has never heard of this skill.
+
+The two layers are complementary, not interchangeable: verbatim phrases optimize for precision on known patterns; the routing directive optimizes for recall across unknown patterns.
+
+#### Additional principles
+
+- **Third-person framing is a routing signal.** "This skill should be used when..." reads as a condition to test. "Use this skill when..." reads as an instruction to execute. The routing model treats these differently.
+- **Include negative triggers for adjacent domains.** Explicit exclusions sharpen the decision boundary. Add "Not for X" when the skill could plausibly false-trigger on a related domain.
+- **The description is always in context.** Every session pays the token cost of every skill's description. Keep it dense — the routing directive eliminates the need for exhaustive trigger phrase lists.
+- **Keep descriptions under 150 tokens (200 absolute max).** Anthropic's hard limit is 1024 characters (~250 tokens). Descriptions longer than 250 characters are truncated. The routing directive adds ~20-30 tokens — the budget accommodates it.
+- **Use `>` scalar, not `|`.** Folded scalar (`>`) collapses newlines to spaces — correct for descriptions. Literal scalar (`|`) preserves newlines, which can break parsing.
 
 ```yaml
-# Correct — verbatim phrases in core, category routing suffix, negative trigger
+# Correct — verbatim anchors, broad routing directive, negative trigger
+description: >
+  This skill should be used when the user asks to "create a hook"
+  or "add lifecycle automation". Make sure to use this skill whenever
+  the user mentions hook authoring, tool-event automation, or
+  validation pipelines — even if they don't explicitly say "hook".
+  Not for modifying existing hooks or debugging hook failures.
+
+# Wrong — exhaustive trigger phrases, no routing directive
 description: >
   This skill should be used when the user asks to "create a hook",
-  "add validation", "implement lifecycle automation", or mentions
-  pre/post tool events. Make sure to use this skill whenever the user
-  mentions hook lifecycle, automation, or tool events — even if they
-  don't explicitly say "hook". Not for modifying existing hooks or
-  debugging hook failures.
+  "add validation", "implement lifecycle automation", "set up
+  pre-tool hooks", "add post-tool cleanup", or "write hook scripts".
 
 # Wrong — vague, no trigger phrases, not third-person
 description: Provides guidance for hooks.
@@ -110,9 +126,23 @@ description: Deploy to staging environment
 
 ---
 
-## Execution Modifiers
+## Essential Field Reference
 
-- **`hooks`** — Run scripts at lifecycle events, scoped to this skill's lifetime. See the Common Frontmatter Options block above for the full structure (matcher, type, timeout, statusMessage, once).
+- **`name`** — Unique identifier. Required for all skills and commands.
+
+- **`description`** — How the routing model decides when to trigger this skill, or the label shown in the `/` menu for commands. See Description Patterns below.
+
+- **`allowed-tools`** — Restrict which tools the skill can use. Default is all tools. See Tool Selection below.
+
+- **`user-invocable`** — Whether the skill appears in the `/` command menu. Default `true`. Set to `false` for background-knowledge skills that should trigger automatically but not appear as slash commands.
+
+- **`argument-hint`** — Shown in autocomplete when the user types the command. Documents expected arguments.
+
+## Advanced Field Reference
+
+These fields add execution control, lifecycle hooks, and platform-specific behavior. Most skills don't need them.
+
+- **`hooks`** — Run scripts at lifecycle events, scoped to this skill's lifetime. See the Advanced Frontmatter block above for the full structure (matcher, type, timeout, statusMessage, once).
 
 - **`context: fork`** — Run the skill in an isolated subagent. The skill content becomes the subagent's prompt; it won't have access to conversation history. Use for task-type skills (deploy, generate, research) where isolation prevents accidental side effects. Pair with `agent` to choose the subagent type (Explore, Plan, general-purpose, or a custom agent from `.claude/agents/`).
 
@@ -120,11 +150,9 @@ description: Deploy to staging environment
 
 - **`paths`** — Glob patterns (comma-separated or YAML list) limiting auto-activation. When set, Claude loads the skill automatically only when working with files matching the patterns. Use for language-specific or framework-specific skills.
 
-- **`shell`** — Shell for `!`backtick`` and ` ```! ` blocks: bash (default) or powershell. Setting powershell runs inline shell commands via PowerShell on Windows.
+- **`shell`** — Shell for `!`backtick`` and ` ```! ` blocks: bash (default) or powershell. Setting powershell runs inline shell commands via PowerShell on Windows. Requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` env var for inline `!` commands to execute via PowerShell.
 
-- **`disable-model-invocation: true`** — Prevent Claude from auto-loading this skill. Use for skills with side effects you want to trigger manually only.
-
-- **`user-invocable: false`** — Hide from the `/` command menu. Use for background-knowledge skills that should trigger automatically but not appear as slash commands.
+- **`disable-model-invocation: true`** — Commands only. Prevents Claude from auto-loading based on description. Has no effect on skills — use `user-invocable: false` instead for skills you want to hide from auto-triggering.
 
 ---
 

--- a/plugins/claude-skills/skills/create-skill/references/frontmatter-options.md
+++ b/plugins/claude-skills/skills/create-skill/references/frontmatter-options.md
@@ -15,6 +15,7 @@ disclosure patterns.
 Every skill needs these fields. Start here.
 
 ```yaml
+# Complete field catalog — most skills only need: name, description, allowed-tools
 ---
 name: identifier                    # Required — unique skill identifier
 description: >                      # How it's described/triggered (see patterns below)
@@ -46,13 +47,13 @@ hooks:
 # Execution context
 context: fork                       # Run in a subagent (isolates from conversation)
 agent: Explore                      # Subagent type when context: fork (default: general-purpose)
-effort: high                        # Override session effort: low | medium | high | max (Opus only)
+effort: high                        # Override session effort: low | medium | high | max (max: Opus 4.6 only)
 paths: "*.py,src/**/*.ts"           # Glob patterns limiting auto-activation to matching files
 shell: bash                         # Shell for !`cmd` blocks: bash (default) or powershell
 
 # Behavior modifiers
 user-invocable: true                # Show in /command menu (default true)
-disable-model-invocation: true      # Prevent programmatic invocation
+disable-model-invocation: true      # Prevent programmatic invocation (commands only)
 argument-hint: "[arg1] [arg2]"      # Document expected arguments; quote if value contains [...]
 ---
 ```
@@ -163,17 +164,11 @@ description: Deploy to staging environment
 
 - **`allowed-tools`** — Restrict which tools the skill can use. Default is all tools. See Tool Selection below.
 
-- **`hooks`** — Run scripts at lifecycle events, scoped to this skill's lifetime. See the Common Frontmatter Options block above for the full structure (matcher, type, timeout, statusMessage, once).
+For `hooks`, `context`, `effort`, and `paths` — see Advanced Field Reference below.
 
-- **`context: fork`** — Run the skill in an isolated subagent. The skill content becomes the subagent's prompt; it won't have access to conversation history. Use for task-type skills (deploy, generate, research) where isolation prevents accidental side effects. Pair with `agent` to choose the subagent type (Explore, Plan, general-purpose, or a custom agent from `.claude/agents/`).
+- **`shell`** — Shell for `!`backtick`` and ` ```! ` blocks: bash (default) or powershell. Setting powershell runs inline shell commands via PowerShell on Windows. Requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` env var for inline `!` commands to execute via PowerShell.
 
-- **`effort`** — Override session effort level for this skill. Options: low, medium, high, max (max is Opus 4.6 only). Use high/max for skills requiring deep reasoning; low for simple lookup skills.
-
-- **`paths`** — Glob patterns (comma-separated or YAML list) limiting auto-activation. When set, Claude loads the skill automatically only when working with files matching the patterns. Use for language-specific or framework-specific skills.
-
-- **`shell`** — Shell for `!`backtick`` and ` ```! ` blocks: bash (default) or powershell. Setting powershell runs inline shell commands via PowerShell on Windows.
-
-- **`disable-model-invocation: true`** — Prevent Claude from auto-loading this skill. Use for skills with side effects you want to trigger manually only.
+- **`disable-model-invocation: true`** — Commands only. Prevents Claude from auto-loading based on description. Has no effect on skills — use `user-invocable: false` instead.
 
 - **`user-invocable`** — Whether the skill appears in the `/` command menu. Default `true`. Set to `false` for background-knowledge skills that should trigger automatically but not appear as slash commands.
 

--- a/plugins/claude-skills/skills/repair-skill/SKILL.md
+++ b/plugins/claude-skills/skills/repair-skill/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: repair-skill
-description: This skill should be used when the user asks to "repair my skill", "audit this skill", "fix my skill", "review skill quality", "check if my skill is well-written", "diagnose skill problems", "what's wrong with this skill", or wants structural correctness fixes. Not for adding features or improving effectiveness — use improve-skill for that. Not for agents — use repair-agent.
+description: >
+  This skill should be used when the user asks to "fix my skill" or "audit this skill".
+  Make sure to use this skill whenever the user mentions skill quality, structural issues,
+  broken skills, or skill diagnostics — even if they don't explicitly say "repair-skill".
+  Not for adding features or improving effectiveness — use improve-skill. Not for agents
+  — use repair-agent.
 argument-hint: <path-to-skill-directory-or-SKILL.md>
 ---
 

--- a/plugins/claude-skills/skills/repair-skill/references/frontmatter-options.md
+++ b/plugins/claude-skills/skills/repair-skill/references/frontmatter-options.md
@@ -18,10 +18,11 @@ be third-person for skills ("This skill should be used when..."), verb-first und
 chars for commands.
 
 Audit rules for description quality:
-- **Token budget:** Under 100 tokens for most skills, 150 absolute max. At 170+ tokens, a 10-skill installation burns ~1,700 tokens per session on routing metadata alone. Prioritize trigger phrases over explanatory prose.
+- **Token budget:** Under 150 tokens for most skills, 200 absolute max. Anthropic's hard limit is 1024 characters (~250 tokens); descriptions over 250 characters are truncated in the skill listing. Prioritize trigger phrases over explanatory prose.
 - **Trigger phrase derivation:** Phrases should be verbatim user speech — the exact words someone would type, not formalized paraphrases. "fix my skill" triggers better than "skill remediation workflow."
 - **Negative triggers:** In crowded domains (multiple skills with overlapping concerns), include "Not for X" or "Don't use for Y" to sharpen the routing decision boundary.
 - **3–5 varied trigger phrases minimum.** Single-phrase descriptions have high miss rates. Include naive phrasing from a user who has never heard of this skill.
+- **Overtriggering check:** Claude tends to undertrigger skills. If the description has no routing directive ("Make sure to use this skill whenever the user mentions [X, Y, Z] — even if they don't explicitly say '[skill name]'"), flag it for the author to consider adding one. The routing suffix uses intent categories and concept words (broad, generalizable), not verbatim query phrases (which overfit). The core uses verbatim phrases (optimized for recall); the suffix uses category words (broad, anti-overfit). These two layers are not interchangeable.
 
 ### `allowed-tools` (list)
 
@@ -82,20 +83,36 @@ restriction is a security and scope risk.
 
 ### `hooks` (object)
 
-Scoped to this skill's lifecycle. Runs scripts before or after specific tool events.
+Scoped to this skill's lifetime — runs only when the skill is active, cleaned up when it
+finishes.
 
 ```yaml
 hooks:
   PreToolUse:
-    - command: "scripts/validate-input.sh"
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "scripts/validate-input.sh"
+          timeout: 10
+          statusMessage: "Validating..."
   PostToolUse:
-    - command: "scripts/cleanup.sh"
+    - hooks:
+        - type: command
+          command: "scripts/cleanup.sh"
   Stop:
-    - command: "scripts/on-complete.sh"
+    - hooks:
+        - type: command
+          command: "scripts/on-complete.sh"
+          once: true
 ```
 
-Valid hook events: `PreToolUse`, `PostToolUse`, `Stop`. Use for validation, logging,
-side effects, or cleanup that must happen deterministically around tool calls.
+All hook events are supported (PreToolUse, PostToolUse, Stop, SessionStart, etc.). Each
+entry can have a `matcher` (filter by tool name) and a `hooks` array with handlers.
+Handler fields: `type` (command, http, prompt, agent), `command`, `timeout` (seconds),
+`statusMessage` (custom spinner text), `once` (skills only — run once then auto-remove).
+
+Audit rule: hooks with no `matcher` fire on every tool call — verify this is intentional.
+Hooks using `once: true` outside of skills are invalid (agents don't support it).
 
 ### `user-invocable` (boolean)
 
@@ -124,6 +141,57 @@ need quoting.
 Audit rule: any skill that reads `$ARGUMENTS` or `$1`/`$2` should have `argument-hint`
 set so users know what to pass.
 
+### `context` (string)
+
+Set to `fork` to run the skill in an isolated subagent. The skill content becomes the
+subagent's prompt; it won't have access to conversation history. Use for task-type skills
+where isolation prevents accidental side effects. Pair with `agent`.
+
+### `agent` (string)
+
+Which subagent type to use when `context: fork` is set. Options: built-in agents
+(`Explore`, `Plan`, `general-purpose`) or custom agents from `.claude/agents/`. If
+omitted, uses `general-purpose`.
+
+Audit rule: `agent` without `context: fork` is dead config — flag it.
+
+### `effort` (string)
+
+Override session effort level: `low`, `medium`, `high`, `max` (max is Opus 4.6 only).
+Use high/max for skills requiring deep reasoning; low for simple lookup skills.
+
+### `paths` (string or list)
+
+Glob patterns limiting auto-activation. When set, Claude loads the skill automatically
+only when working with files matching the patterns. Accepts comma-separated string or
+YAML list. Uses the same format as path-specific rules in CLAUDE.md.
+
+Audit rule: skills with `paths` set should not also have broad descriptions — the path
+filter narrows scope, so the description should match that narrowed scope.
+
+### `shell` (string)
+
+Shell for `!`backtick`` and ` ```! ` blocks: `bash` (default) or `powershell`. Only
+relevant for skills using inline shell execution.
+
+---
+
+## Skill Content Lifecycle
+
+When invoked, the rendered SKILL.md enters the conversation as a single message and stays
+for the rest of the session. Claude Code does not re-read the file on later turns — write
+guidance as standing instructions, not one-time steps.
+
+Auto-compaction carries invoked skills forward within a token budget: the first 5,000
+tokens of each skill are retained after compaction, and all recently invoked skills share
+a combined 25,000-token budget (filled most-recent-first). Skills exceeding 5,000 tokens
+lose their tail after compaction. Skills invoked long ago may be dropped entirely if the
+budget is exhausted.
+
+Audit relevance: if a skill's critical instructions appear after the first ~5,000 tokens,
+they will be lost after compaction. Flag this as a structural issue — front-load critical
+content or move reference material to separate files.
+
 ---
 
 ## Dynamic Content Syntax
@@ -133,10 +201,12 @@ These substitutions are processed before the skill body reaches Claude.
 | Syntax | Resolves to |
 |--------|-------------|
 | `$ARGUMENTS` | All arguments passed to the skill as a single string |
-| `$1`, `$2`, `$3` | Individual positional arguments |
+| `$1`, `$2`, `$3` | Individual positional arguments (shell-style quoting for multi-word values) |
 | `@path/to/file` | Contents of the file at that path, loaded inline |
 | `@$1` | Contents of the file whose path was passed as the first argument |
 | bang + backtick-wrapped command (e.g. `!date`) | Output of executing the command in a shell, injected inline |
+| `${CLAUDE_SKILL_DIR}` | Path to the skill's own directory (for referencing bundled scripts/files) |
+| `${CLAUDE_SESSION_ID}` | Current session ID (for logging or session-specific output files) |
 
 Audit rule: skills that accept a file path as input should use `@$1` to load it inline
 rather than requiring a separate Read tool call — the injection happens before the model


### PR DESCRIPTION
## Summary
- Sync both `frontmatter-options.md` copies (create-skill + repair-skill) with official Claude Code documentation
- Add the two-layer "pushy description" pattern from Anthropic's skill-creator guidance
- Raise description token budget from 100/150 to 150/200

## Changes

### New frontmatter fields (missing from both copies)
- `context` — run skill in isolated subagent (`fork`)
- `agent` — subagent type when context: fork
- `effort` — override session effort level (low/medium/high/max)
- `paths` — glob patterns limiting auto-activation to matching files
- `shell` — choose bash or powershell for inline commands

### Richer hooks syntax
- Updated from simplified `command:` format to official structure with matcher, type, timeout, statusMessage, once
- All hook events now documented (was missing SessionStart and others)

### Pushy description pattern
- Added "Err toward overtriggering" principle with two-layer pattern: verbatim phrases in core, category routing directive in suffix
- Added undertriggering audit rule to repair-skill

### Other additions
- Skill content lifecycle section (compaction: 5K per skill, 25K combined budget)
- `${CLAUDE_SKILL_DIR}` and `${CLAUDE_SESSION_ID}` string substitutions
- Updated create-skill SKILL.md body to match new budget and reference pushy pattern

## Diff Stat
```
7 files changed, 150 insertions(+), 25 deletions(-)
```

## Test plan
- [ ] Invoke `/create-skill` and verify it reads the updated frontmatter-options.md
- [ ] Invoke `/repair-skill` on a skill with a conservative description — verify it flags the missing routing directive
- [ ] Check that the hooks example in frontmatter-options.md is valid YAML