### PR TITLE
fix(memory): make import and ingest append-only, WAL-safe backup before migration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.82",
+      "version": "0.8.83",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.83",
+      "version": "0.8.84",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.84",
+      "version": "0.8.85",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.81",
+      "version": "0.8.82",
       "source": "./plugins/claude-memory"
     },
     {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.81](https://img.shields.io/badge/v0.8.81-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.82](https://img.shields.io/badge/v0.8.82-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.84](https://img.shields.io/badge/v0.8.84-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.85](https://img.shields.io/badge/v0.8.85-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.83](https://img.shields.io/badge/v0.8.83-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.84](https://img.shields.io/badge/v0.8.84-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.82](https://img.shields.io/badge/v0.8.82-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.83](https://img.shields.io/badge/v0.8.83-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.83",
+  "version": "0.8.84",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.81",
+  "version": "0.8.82",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.82",
+  "version": "0.8.83",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.84",
+  "version": "0.8.85",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.83](https://img.shields.io/badge/v0.8.83-blue?style=flat-square)
+# claude-memory ![v0.8.84](https://img.shields.io/badge/v0.8.84-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.84](https://img.shields.io/badge/v0.8.84-blue?style=flat-square)
+# claude-memory ![v0.8.85](https://img.shields.io/badge/v0.8.85-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.82](https://img.shields.io/badge/v0.8.82-blue?style=flat-square)
+# claude-memory ![v0.8.83](https://img.shields.io/badge/v0.8.83-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.81](https://img.shields.io/badge/v0.8.81-blue?style=flat-square)
+# claude-memory ![v0.8.82](https://img.shields.io/badge/v0.8.82-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/hooks/import_conversations.py
+++ b/plugins/claude-memory/hooks/import_conversations.py
@@ -16,7 +16,6 @@ import json
 import sqlite3
 import sys
 from pathlib import Path
-from typing import Optional
 
 # Add path to shared utils
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -48,7 +47,6 @@ def import_session(
     conn: sqlite3.Connection,
     filepath: Path,
     project_id: int,
-    parent_session_id: Optional[int] = None
 ) -> tuple[int, int]:
     """
     Import a single session JSONL file with v3 schema.
@@ -92,13 +90,12 @@ def import_session(
 
     # Step 1: Upsert ONE session row
     cursor.execute("""
-        INSERT INTO sessions (uuid, project_id, parent_session_id, git_branch, cwd)
-        VALUES (?, ?, ?, ?, ?)
+        INSERT INTO sessions (uuid, project_id, git_branch, cwd)
+        VALUES (?, ?, ?, ?)
         ON CONFLICT(uuid) DO UPDATE SET
             git_branch = COALESCE(excluded.git_branch, sessions.git_branch),
-            cwd = COALESCE(excluded.cwd, sessions.cwd),
-            parent_session_id = COALESCE(excluded.parent_session_id, sessions.parent_session_id)
-    """, (session_uuid, project_id, parent_session_id, meta["git_branch"], meta["cwd"]))
+            cwd = COALESCE(excluded.cwd, sessions.cwd)
+    """, (session_uuid, project_id, meta["git_branch"], meta["cwd"]))
     cursor.execute("SELECT id FROM sessions WHERE uuid = ?", (session_uuid,))
     session_id = cursor.fetchone()[0]
 
@@ -371,32 +368,6 @@ def import_project(
         else:
             sessions_imported += branches_count
             messages_imported += msg_count
-
-        # Check for subagents
-        session_uuid = jsonl_file.stem
-        subagents_dir = project_dir / session_uuid / "subagents"
-        if subagents_dir.exists():
-            for subagent_file in subagents_dir.glob("*.jsonl"):
-                # Skip prompt_suggestion agents (autocomplete noise)
-                if "prompt_suggestion" in subagent_file.stem:
-                    sessions_skipped += 1
-                    continue
-                # For subagents, find parent session id
-                cursor.execute(
-                    "SELECT id FROM sessions WHERE uuid = ? LIMIT 1",
-                    (session_uuid,)
-                )
-                parent_row = cursor.fetchone()
-                parent_sid = parent_row[0] if parent_row else None
-
-                sub_branches, sub_msg_count = import_session(
-                    conn, subagent_file, project_id, parent_session_id=parent_sid
-                )
-                if sub_branches != -1:
-                    sessions_imported += sub_branches
-                    messages_imported += sub_msg_count
-                else:
-                    sessions_skipped += 1
 
     return sessions_imported, messages_imported, sessions_skipped
 

--- a/plugins/claude-memory/hooks/import_conversations.py
+++ b/plugins/claude-memory/hooks/import_conversations.py
@@ -289,12 +289,8 @@ def import_session(
     # Check if session has any branches at all (pre-existing + new)
     cursor.execute("SELECT COUNT(*) FROM branches WHERE session_id = ?", (session_id,))
     if cursor.fetchone()[0] == 0:
-        # No branches but messages may exist (FK constraint prevents session delete).
-        # Check if session is truly empty (no messages either) before removing.
-        cursor.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,))
-        if cursor.fetchone()[0] == 0:
-            cursor.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
-        # Either way, nothing useful was imported for branch-based search
+        # Messages exist (guaranteed by early return above) but no branches —
+        # nothing useful for branch-based search.
         return -1, 0
 
     # Step 5: Update import_log

--- a/plugins/claude-memory/hooks/import_conversations.py
+++ b/plugins/claude-memory/hooks/import_conversations.py
@@ -102,17 +102,13 @@ def import_session(
     cursor.execute("SELECT id FROM sessions WHERE uuid = ?", (session_uuid,))
     session_id = cursor.fetchone()[0]
 
-    # Step 2: Clear existing data for re-import (FK-safe order: branch_messages → branches → messages)
-    cursor.execute("SELECT id FROM branches WHERE session_id = ?", (session_id,))
-    old_branch_ids = [row[0] for row in cursor.fetchall()]
-    if old_branch_ids:
-        placeholders = ",".join("?" * len(old_branch_ids))
-        # Placeholders are auto-generated "?" strings; values are DB-generated integers
-        cursor.execute(f"DELETE FROM branch_messages WHERE branch_id IN ({placeholders})", old_branch_ids)
-    cursor.execute("DELETE FROM branches WHERE session_id = ?", (session_id,))
-    cursor.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+    # Step 2: Append-only message insert (never delete — JSONL source expires after 30 days)
+    # Build set of UUIDs claimed by any branch to filter noise
+    valid_branch_uuids = set()
+    for branch in branches:
+        valid_branch_uuids.update(branch["uuids"])
 
-    total_messages = 0
+    new_messages = 0
     for entry in messages:
         entry_type = entry.get("type")
         if entry_type not in ("user", "assistant"):
@@ -122,6 +118,10 @@ def import_session(
         content = message.get("content", "")
 
         if entry_type == "user" and is_tool_result(content):
+            continue
+
+        uuid = entry.get("uuid")
+        if not uuid or uuid not in valid_branch_uuids:
             continue
 
         notification = 1 if (entry_type == "user" and (is_task_notification(content) or is_teammate_message(content))) else 0
@@ -138,7 +138,7 @@ def import_session(
             ON CONFLICT(session_id, uuid) DO NOTHING
         """, (
             session_id,
-            entry.get("uuid"),
+            uuid,
             entry.get("parentUuid"),
             entry.get("timestamp"),
             entry_type,
@@ -150,10 +150,15 @@ def import_session(
             origin,
         ))
         if cursor.rowcount > 0:
-            total_messages += 1
+            new_messages += 1
 
-    # Skip sessions with no extractable messages
+    # Check total message count (pre-existing + new) — not just new inserts
+    cursor.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,))
+    total_messages = cursor.fetchone()[0]
+
+    # Skip sessions with no extractable messages at all
     if total_messages == 0:
+        # Safe to remove: session was just created with no data
         cursor.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
         return -1, 0
 
@@ -164,7 +169,12 @@ def import_session(
     )
     uuid_to_msg_id = {row[1]: row[0] for row in cursor.fetchall()}
 
-    # Step 4: Build branches + branch_messages
+    # Step 4: Upsert branches + diff branch_messages (mirrors sync_current.py)
+    cursor.execute(
+        "SELECT id, leaf_uuid FROM branches WHERE session_id = ?",
+        (session_id,)
+    )
+    existing_branches = {row[1]: row[0] for row in cursor.fetchall()}
     branches_imported = 0
 
     for branch in branches:
@@ -184,40 +194,79 @@ def import_session(
         branch_meta = extract_session_metadata(branch_msgs)
         exchange_count, files, commits, tool_counts = compute_branch_metadata(branch_msgs)
 
-        # Insert branch
-        cursor.execute("""
-            INSERT INTO branches (session_id, leaf_uuid, fork_point_uuid, is_active,
-                                  started_at, ended_at, exchange_count, files_modified, commits, tool_counts)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """, (
-            session_id,
-            leaf_uuid,
-            fork_point_uuid,
-            int(is_active),
-            branch_meta["started_at"],
-            branch_meta["ended_at"],
-            exchange_count,
-            json.dumps(files) if files else None,
-            json.dumps(commits) if commits else None,
-            json.dumps(tool_counts) if tool_counts else None
-        ))
-        branch_db_id = cursor.lastrowid
+        files_json = json.dumps(files) if files else None
+        commits_json = json.dumps(commits) if commits else None
+        tool_counts_json = json.dumps(tool_counts) if tool_counts else None
 
-        # Insert branch_messages mapping
+        if leaf_uuid in existing_branches:
+            # Update existing branch metadata
+            branch_db_id = existing_branches[leaf_uuid]
+            cursor.execute("""
+                UPDATE branches SET
+                    is_active = ?, fork_point_uuid = ?,
+                    started_at = ?, ended_at = ?,
+                    exchange_count = ?, files_modified = ?, commits = ?, tool_counts = ?
+                WHERE id = ?
+            """, (
+                int(is_active), fork_point_uuid,
+                branch_meta["started_at"], branch_meta["ended_at"],
+                exchange_count, files_json, commits_json, tool_counts_json,
+                branch_db_id
+            ))
+        else:
+            # Insert new branch
+            cursor.execute("""
+                INSERT INTO branches (session_id, leaf_uuid, fork_point_uuid, is_active,
+                                      started_at, ended_at, exchange_count, files_modified, commits, tool_counts)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                session_id, leaf_uuid, fork_point_uuid, int(is_active),
+                branch_meta["started_at"], branch_meta["ended_at"],
+                exchange_count, files_json, commits_json, tool_counts_json
+            ))
+            branch_db_id = cursor.lastrowid
+
+        # Ensure only one active branch per session
+        if is_active:
+            cursor.execute("""
+                UPDATE branches SET is_active = 0
+                WHERE session_id = ? AND id != ? AND is_active = 1
+            """, (session_id, branch_db_id))
+
+        # Diff branch_messages: add missing, remove stale links (not messages)
+        cursor.execute(
+            "SELECT message_id FROM branch_messages WHERE branch_id = ?",
+            (branch_db_id,)
+        )
+        existing_bm_ids = {row[0] for row in cursor.fetchall()}
+
+        desired_bm_ids = set()
         for uuid in branch_uuids:
             msg_id = uuid_to_msg_id.get(uuid)
             if msg_id:
-                cursor.execute(
-                    "INSERT OR IGNORE INTO branch_messages (branch_id, message_id) VALUES (?, ?)",
-                    (branch_db_id, msg_id)
-                )
+                desired_bm_ids.add(msg_id)
+
+        to_add = desired_bm_ids - existing_bm_ids
+        to_remove = existing_bm_ids - desired_bm_ids
+
+        if to_remove:
+            ph = ",".join("?" * len(to_remove))
+            cursor.execute(
+                f"DELETE FROM branch_messages WHERE branch_id = ? AND message_id IN ({ph})",
+                (branch_db_id, *to_remove)
+            )
+        if to_add:
+            cursor.executemany(
+                "INSERT OR IGNORE INTO branch_messages (branch_id, message_id) VALUES (?, ?)",
+                [(branch_db_id, mid) for mid in to_add]
+            )
 
         # Aggregate branch content for FTS
         agg_content = aggregate_branch_content(cursor, branch_db_id)
         if not agg_content:
-            # No searchable content — remove this branch
-            cursor.execute("DELETE FROM branch_messages WHERE branch_id = ?", (branch_db_id,))
-            cursor.execute("DELETE FROM branches WHERE id = ?", (branch_db_id,))
+            # No searchable content — skip but don't delete. Deleting causes
+            # thrashing: branch exists in JSONL → recreated next import → empty
+            # again → deleted again, every cycle. An empty branch row is harmless.
             continue
 
         cursor.execute(
@@ -237,20 +286,15 @@ def import_session(
 
         branches_imported += 1
 
-    # Clean up orphaned messages (not referenced by any branch)
-    cursor.execute("""
-        DELETE FROM messages
-        WHERE session_id = ? AND id NOT IN (
-            SELECT DISTINCT bm.message_id FROM branch_messages bm
-            JOIN branches b ON bm.branch_id = b.id
-            WHERE b.session_id = ?
-        )
-    """, (session_id, session_id))
-
-    # If no branches survived, remove the empty session
-    if branches_imported == 0:
-        cursor.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
-        cursor.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+    # Check if session has any branches at all (pre-existing + new)
+    cursor.execute("SELECT COUNT(*) FROM branches WHERE session_id = ?", (session_id,))
+    if cursor.fetchone()[0] == 0:
+        # No branches but messages may exist (FK constraint prevents session delete).
+        # Check if session is truly empty (no messages either) before removing.
+        cursor.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,))
+        if cursor.fetchone()[0] == 0:
+            cursor.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+        # Either way, nothing useful was imported for branch-based search
         return -1, 0
 
     # Step 5: Update import_log

--- a/plugins/claude-memory/skills/get-token-insights/scripts/ingest_token_data.py
+++ b/plugins/claude-memory/skills/get-token-insights/scripts/ingest_token_data.py
@@ -25,7 +25,7 @@ DASHBOARD_OUT_PATH = DB_PATH.parent / "dashboard.html"
 BATCH_SIZE = 50
 PROGRESS_INTERVAL = 100
 COMMAND_TRUNCATE = 200
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 # SQL fragment: true Bash antipatterns — standalone cat/grep/find/ls that have
 # a dedicated tool equivalent. Excludes legitimate patterns:
@@ -183,12 +183,13 @@ CREATE TABLE IF NOT EXISTS hook_executions (
 CREATE INDEX IF NOT EXISTS idx_he_session ON hook_executions(session_id);
 CREATE INDEX IF NOT EXISTS idx_he_command ON hook_executions(hook_command);
 
-CREATE TABLE IF NOT EXISTS import_log (
+CREATE TABLE IF NOT EXISTS token_import_log (
   id INTEGER PRIMARY KEY,
   file_path TEXT UNIQUE NOT NULL,
-  file_hash TEXT,
+  session_id TEXT,
   imported_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  messages_imported INTEGER DEFAULT 0
+  turn_count INTEGER DEFAULT 0,
+  mtime_ns INTEGER
 );
 """
 
@@ -232,11 +233,6 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             conn.execute(f"ALTER TABLE token_snapshots ADD COLUMN {col} {typedef}")
         except sqlite3.OperationalError:
             pass
-    # Ensure import_log has mtime_ns
-    try:
-        conn.execute("ALTER TABLE import_log ADD COLUMN mtime_ns INTEGER")
-    except sqlite3.OperationalError:
-        pass
     # Add new workflow-analytics columns if missing (v2 schema)
     for col, typedef in [("skill_name", "TEXT"), ("subagent_type", "TEXT"), ("agent_model", "TEXT")]:
         try:
@@ -255,7 +251,7 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
     current = row[0] if row else 0
     if current < SCHEMA_VERSION:
         print(f"Schema upgraded to v{SCHEMA_VERSION} — full re-import required", file=sys.stderr)
-        conn.execute("DELETE FROM import_log")
+        conn.execute("DELETE FROM token_import_log")
         if current == 0:
             conn.execute("INSERT INTO schema_version (version) VALUES (?)", (SCHEMA_VERSION,))
         else:
@@ -309,7 +305,7 @@ def should_skip_file(conn: sqlite3.Connection, filepath: Path) -> bool:
     except OSError:
         return True
     cur = conn.execute(
-        "SELECT mtime_ns FROM import_log WHERE file_path = ?",
+        "SELECT mtime_ns FROM token_import_log WHERE file_path = ?",
         (str(filepath),)
     )
     row = cur.fetchone()
@@ -321,7 +317,7 @@ def should_skip_file(conn: sqlite3.Connection, filepath: Path) -> bool:
 def record_import(conn: sqlite3.Connection, filepath: Path, session_id: str, turn_count: int) -> None:
     mtime_ns = filepath.stat().st_mtime_ns
     conn.execute(
-        """INSERT OR REPLACE INTO import_log (file_path, file_hash, imported_at, messages_imported, mtime_ns)
+        """INSERT OR REPLACE INTO token_import_log (file_path, session_id, imported_at, turn_count, mtime_ns)
            VALUES (?, ?, datetime('now'), ?, ?)""",
         (str(filepath), session_id, turn_count, mtime_ns)
     )
@@ -684,16 +680,18 @@ def compute_session_analytics(session: ParsedSession) -> dict:
 def import_session(conn: sqlite3.Connection, session: ParsedSession, jnl: JnlFile) -> None:
     sid = session.session_id
 
-    # Delete existing data for this session (idempotent re-import)
-    conn.execute("DELETE FROM hook_executions WHERE session_id = ?", (sid,))
-    conn.execute("DELETE FROM turn_tool_calls WHERE session_id = ?", (sid,))
-    conn.execute("DELETE FROM turns WHERE session_id = ?", (sid,))
-    conn.execute("DELETE FROM session_metrics WHERE session_id = ?", (sid,))
-
+    # Append-only: insert new turns, skip existing (JSONL source expires after 30 days)
     analytics = compute_session_analytics(session)
 
-    # Insert turns
     for turn in session.turns:
+        # Skip turns that already exist
+        existing = conn.execute(
+            "SELECT id FROM turns WHERE session_id = ? AND turn_index = ?",
+            (sid, turn.index)
+        ).fetchone()
+        if existing:
+            continue
+
         conn.execute(
             """INSERT INTO turns (session_id, turn_index, timestamp, model,
                input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
@@ -708,7 +706,7 @@ def import_session(conn: sqlite3.Connection, session: ParsedSession, jnl: JnlFil
         )
         turn_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
 
-        # Insert tool calls
+        # Insert tool calls only for newly inserted turns
         for tc in turn.tool_calls:
             conn.execute(
                 """INSERT INTO turn_tool_calls (turn_id, session_id, tool_name, tool_use_id,
@@ -720,12 +718,12 @@ def import_session(conn: sqlite3.Connection, session: ParsedSession, jnl: JnlFil
                  tc.skill_name, tc.subagent_type, tc.agent_model)
             )
 
-    # Insert session_metrics
+    # Upsert session_metrics — summary recalculated from full data on each pass
     first_ts = session.turns[0].timestamp if session.turns else None
     last_ts = session.turns[-1].timestamp if session.turns else None
 
     conn.execute(
-        """INSERT INTO session_metrics (session_id, project_path, git_branch, cc_version,
+        """INSERT OR REPLACE INTO session_metrics (session_id, project_path, git_branch, cc_version,
            slug, entrypoint, is_sidechain, parent_session_id,
            first_turn_ts, last_turn_ts, turn_count, user_msg_count,
            total_input_tokens, total_output_tokens, total_cache_read, total_cache_creation,
@@ -752,13 +750,17 @@ def import_session(conn: sqlite3.Connection, session: ParsedSession, jnl: JnlFil
          analytics["model_switch_count"])
     )
 
-    # Insert per-hook execution records
-    for hc in session.hook_calls:
-        conn.execute(
-            """INSERT INTO hook_executions (session_id, hook_command, duration_ms, is_error)
-               VALUES (?,?,?,?)""",
-            (sid, hc["hook_command"], hc["duration_ms"], hc["is_error"])
-        )
+    # Insert hook executions only if none exist for this session (hooks don't change mid-session)
+    has_hooks = conn.execute(
+        "SELECT 1 FROM hook_executions WHERE session_id = ? LIMIT 1", (sid,)
+    ).fetchone()
+    if not has_hooks:
+        for hc in session.hook_calls:
+            conn.execute(
+                """INSERT INTO hook_executions (session_id, hook_command, duration_ms, is_error)
+                   VALUES (?,?,?,?)""",
+                (sid, hc["hook_command"], hc["duration_ms"], hc["is_error"])
+            )
 
 
 # ── Backfill token_snapshots ─────────────────────────────────────────

--- a/plugins/claude-memory/skills/get-token-insights/scripts/ingest_token_data.py
+++ b/plugins/claude-memory/skills/get-token-insights/scripts/ingest_token_data.py
@@ -683,13 +683,14 @@ def import_session(conn: sqlite3.Connection, session: ParsedSession, jnl: JnlFil
     # Append-only: insert new turns, skip existing (JSONL source expires after 30 days)
     analytics = compute_session_analytics(session)
 
+    # Prefetch existing turn indices to avoid N+1 queries on reimport
+    existing_indices = {
+        row[0] for row in conn.execute(
+            "SELECT turn_index FROM turns WHERE session_id = ?", (sid,)
+        )
+    }
     for turn in session.turns:
-        # Skip turns that already exist
-        existing = conn.execute(
-            "SELECT id FROM turns WHERE session_id = ? AND turn_index = ?",
-            (sid, turn.index)
-        ).fetchone()
-        if existing:
+        if turn.index in existing_indices:
             continue
 
         conn.execute(

--- a/plugins/claude-memory/skills/get-token-insights/scripts/ingest_token_data.py
+++ b/plugins/claude-memory/skills/get-token-insights/scripts/ingest_token_data.py
@@ -252,6 +252,8 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
     if current < SCHEMA_VERSION:
         print(f"Schema upgraded to v{SCHEMA_VERSION} — full re-import required", file=sys.stderr)
         conn.execute("DELETE FROM token_import_log")
+        # Drop the legacy import_log table from pre-v4 schemas; replaced by token_import_log.
+        conn.execute("DROP TABLE IF EXISTS import_log")
         if current == 0:
             conn.execute("INSERT INTO schema_version (version) VALUES (?)", (SCHEMA_VERSION,))
         else:
@@ -751,7 +753,11 @@ def import_session(conn: sqlite3.Connection, session: ParsedSession, jnl: JnlFil
          analytics["model_switch_count"])
     )
 
-    # Insert hook executions only if none exist for this session (hooks don't change mid-session)
+    # Insert hook executions only if none exist for this session. Intentional trade-off: on
+    # re-import (JSONL file grown since first ingest), session_metrics.total_hook_ms is
+    # recomputed from the full file, but hook_executions stays frozen at the first-import
+    # count. This avoids duplicate rows for hooks that were already recorded; the aggregate
+    # metric stays accurate while per-row hook analytics may undercount later hooks.
     has_hooks = conn.execute(
         "SELECT 1 FROM hook_executions WHERE session_id = ? LIMIT 1", (sid,)
     ).fetchone()

--- a/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/db.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/db.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 import logging
-import shutil
 import sqlite3
 import time
 from logging.handlers import RotatingFileHandler
@@ -241,7 +240,7 @@ def migrate_db(conn: sqlite3.Connection) -> bool:
     if not cursor.fetchone():
         return False  # Fresh DB, no migration needed
 
-    # Old schema detected — nuke and recreate
+    # Old schema detected — backup then nuke and recreate
     db_path = None
     # Get the database file path from connection
     cursor.execute("PRAGMA database_list")
@@ -253,7 +252,20 @@ def migrate_db(conn: sqlite3.Connection) -> bool:
     conn.close()
 
     if db_path and db_path.exists():
+        # JSONL source files expire after 30 days — data older than that
+        # exists only in this DB. Back up before destroying.
+        backed_up = _backup_db_before_migration(db_path, "pre-v3-nuke")
+        if not backed_up:
+            # Backup failed (disk full, permissions, etc.) — refuse to destroy
+            # the only copy. Return False so caller uses the old schema as-is.
+            return False
         db_path.unlink()
+        # Clean up WAL/SHM files — orphaned WAL replayed into an empty DB
+        # causes "database disk image is malformed" errors.
+        for suffix in ("-wal", "-shm"):
+            wal_path = db_path.with_name(db_path.name + suffix)
+            if wal_path.exists():
+                wal_path.unlink()
 
     # Reconnect and create fresh schema
     new_conn = sqlite3.connect(str(db_path) if db_path else ":memory:")
@@ -459,27 +471,40 @@ CREATE INDEX IF NOT EXISTS idx_token_snapshots_start ON token_snapshots(start_ti
         conn.commit()
 
 
-def _backup_db_before_migration(db_path: Path, label: str) -> None:
-    """Create a timestamped backup of the DB before a destructive migration."""
+def _backup_db_before_migration(db_path: Path, label: str) -> bool:
+    """Create a timestamped WAL-safe backup using sqlite3.Connection.backup().
+
+    Returns True if backup succeeded and was verified, False otherwise.
+    sqlite3.Connection.backup() does a page-level copy that respects WAL journaling.
+    """
     if not db_path.name or not db_path.exists():
-        return
+        return False
     ts = time.strftime("%Y%m%d-%H%M%S")
     backup_path = db_path.with_suffix(f".pre-{label}-{ts}.db")
     try:
-        shutil.copy2(db_path, backup_path)
-    except OSError:
-        pass  # Best-effort — don't block migration if backup fails
+        src = sqlite3.connect(str(db_path))
+        dst = sqlite3.connect(str(backup_path))
+        src.backup(dst)
+        dst.close()
+        src.close()
+        # Verify backup is non-empty
+        if not backup_path.exists() or backup_path.stat().st_size == 0:
+            return False
+        return True
+    except Exception:
+        return False
 
 
 def _backfill_origin(conn: sqlite3.Connection, cursor: sqlite3.Cursor) -> None:
     """Selectively backfill origin column from JSONL files without full reimport.
 
-    Phase 1: For each file in import_log, scan for entries with origin fields
+    For each file in import_log, scan for entries with origin fields
     and UPDATE existing message rows by session_id + uuid.
 
-    Phase 2: For files containing isMeta+origin entries (channel messages that
-    were previously filtered by the parser), nullify file_hash so the next
-    normal import re-processes just those sessions via the standard pipeline.
+    Note: Previously had a Phase 2 that nullified file_hash to force reimport
+    of sessions with channel messages. Removed because the reimport path is
+    destructive (delete-all-then-insert) and JSONL files expire after 30 days —
+    triggering a reimport risks irrecoverable data loss.
     """
     import json
     from memory_lib.content import parse_origin
@@ -509,7 +534,6 @@ def _backfill_origin(conn: sqlite3.Connection, cursor: sqlite3.Cursor) -> None:
         if not p.exists():
             continue
 
-        has_channel_messages = False
         try:
             with open(p, "r", encoding="utf-8", errors="replace") as f:
                 for line in f:
@@ -525,11 +549,7 @@ def _backfill_origin(conn: sqlite3.Connection, cursor: sqlite3.Cursor) -> None:
                     if not origin:
                         continue
 
-                    # Phase 2 detection: isMeta entries with origin were previously skipped
-                    if obj.get("isMeta"):
-                        has_channel_messages = True
-
-                    # Phase 1: UPDATE origin for existing messages
+                    # UPDATE origin for existing messages
                     uuid = obj.get("uuid")
                     if uuid and obj.get("type") in ("user", "assistant"):
                         origin_value = parse_origin(obj)
@@ -540,13 +560,6 @@ def _backfill_origin(conn: sqlite3.Connection, cursor: sqlite3.Cursor) -> None:
                             )
         except OSError:
             continue
-
-        # Phase 2: Nullify hash so next import re-processes this session
-        if has_channel_messages:
-            cursor.execute(
-                "UPDATE import_log SET file_hash = NULL WHERE file_path = ?",
-                (file_path,)
-            )
 
     conn.commit()
 

--- a/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/db.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/db.py
@@ -249,8 +249,6 @@ def migrate_db(conn: sqlite3.Connection) -> bool:
             db_path = Path(row[2])
             break
 
-    conn.close()
-
     if db_path and db_path.exists():
         # JSONL source files expire after 30 days — data older than that
         # exists only in this DB. Back up before destroying.
@@ -259,6 +257,7 @@ def migrate_db(conn: sqlite3.Connection) -> bool:
             # Backup failed (disk full, permissions, etc.) — refuse to destroy
             # the only copy. Return False so caller uses the old schema as-is.
             return False
+        conn.close()
         db_path.unlink()
         # Clean up WAL/SHM files — orphaned WAL replayed into an empty DB
         # causes "database disk image is malformed" errors.
@@ -481,18 +480,23 @@ def _backup_db_before_migration(db_path: Path, label: str) -> bool:
         return False
     ts = time.strftime("%Y%m%d-%H%M%S")
     backup_path = db_path.with_suffix(f".pre-{label}-{ts}.db")
+    src = None
+    dst = None
     try:
         src = sqlite3.connect(str(db_path))
         dst = sqlite3.connect(str(backup_path))
         src.backup(dst)
-        dst.close()
-        src.close()
         # Verify backup is non-empty
         if not backup_path.exists() or backup_path.stat().st_size == 0:
             return False
         return True
     except Exception:
         return False
+    finally:
+        if dst:
+            dst.close()
+        if src:
+            src.close()
 
 
 def _backfill_origin(conn: sqlite3.Connection, cursor: sqlite3.Cursor) -> None:

--- a/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/summarizer.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/summarizer.py
@@ -15,23 +15,6 @@ import sqlite3
 
 from memory_lib.formatting import format_time, format_time_full
 
-# --- Marker extraction heuristics ---
-
-# Keyword patterns: (compiled_regex, marker_type)
-_KEYWORD_PATTERNS = [
-    (re.compile(r"(?:decided|let'?s go with|chose|the plan is|we(?:'re| are) going with)\s+(.{10,120})", re.IGNORECASE), "DECIDED"),
-    (re.compile(r"(?:next step|TODO|need to|we should|the next thing)\s*(?:is|:)?\s*(.{10,120})", re.IGNORECASE), "NEXT"),
-    (re.compile(r"(?:blocked on|waiting for|can'?t proceed|depends on)\s+(.{10,120})", re.IGNORECASE), "OPEN"),
-    (re.compile(r"(?:skip(?:ped)?|don'?t|instead of|not going to|rejected)\s+(.{10,120})", re.IGNORECASE), "REJECTED"),
-]
-
-# User intent prefixes
-_INTENT_RE = re.compile(r"^(?:let'?s|can you|I want|we need to|I need)\s+(.{10,120})", re.IGNORECASE | re.MULTILINE)
-
-# Max markers per type and total
-_MAX_PER_TYPE = 3
-_MAX_TOTAL = 10
-
 # Truncation limits
 _FRONT_CHARS = 300
 _BACK_CHARS = 600
@@ -57,19 +40,6 @@ def truncate_mid(text: str, front: int = _FRONT_CHARS, back: int = _BACK_CHARS) 
     if not text or len(text) <= front + back + 20:
         return text
     return text[:front] + "\n[... truncated ...]\n" + text[-back:]
-
-
-def _last_sentence(text: str) -> str:
-    """Extract the last sentence from text."""
-    # Split on sentence boundaries
-    sentences = re.split(r'(?<=[.!?])\s+', text.strip())
-    return sentences[-1] if sentences else ""
-
-
-def _extract_bullet_items(text: str) -> list[str]:
-    """Extract bullet or numbered list items from text."""
-    items = re.findall(r'^[\s]*[-*\d.]+\s+(.+)$', text, re.MULTILINE)
-    return items[:5]
 
 
 def detect_disposition(exchanges: list[dict]) -> str:
@@ -104,90 +74,6 @@ def detect_disposition(exchanges: list[dict]) -> str:
         return "COMPLETED"
 
     return "IN_PROGRESS"
-
-
-def extract_markers(exchanges: list[dict]) -> list[dict]:
-    """
-    Run heuristic layers on exchange pairs to extract structured markers.
-
-    Each exchange is {"user": str, "assistant": str, "index": int}.
-    Returns list of {"type": str, "text": str, "source_exchange": int}.
-    """
-    markers = []  # type: list[dict]
-    seen_texts = set()  # type: set[str]
-
-    def _add(marker_type: str, text: str, source: int) -> None:
-        text = text.strip()
-        if not text or len(text) < 10:
-            return
-        # Truncate long markers
-        if len(text) > 150:
-            text = text[:147] + "..."
-        # Dedup by substring containment
-        text_lower = text.lower()
-        for existing in seen_texts:
-            if text_lower in existing or existing in text_lower:
-                return
-        seen_texts.add(text_lower)
-        markers.append({"type": marker_type, "text": text, "source_exchange": source})
-
-    for ex in exchanges:
-        idx = ex.get("index", 0)
-        asst = ex.get("assistant", "")
-        user = ex.get("user", "")
-
-        # Layer 1: Keyword matching on assistant text
-        for pattern, marker_type in _KEYWORD_PATTERNS:
-            for match in pattern.finditer(asst):
-                _add(marker_type, match.group(0), idx)
-
-        # Layer 4: User intent prefixes
-        for match in _INTENT_RE.finditer(user):
-            _add("OPEN", match.group(0), idx)
-
-        # Layer 5: Negation tracking in user messages
-        for pattern, marker_type in _KEYWORD_PATTERNS:
-            if marker_type == "REJECTED":
-                for match in pattern.finditer(user):
-                    _add("REJECTED", match.group(0), idx)
-
-    # Layer 2: Positional — last exchange gets special treatment
-    if exchanges:
-        last = exchanges[-1]
-        last_asst = last.get("assistant", "")
-        last_idx = last.get("index", 0)
-
-        # Last sentence of final assistant response
-        last_sent = _last_sentence(last_asst)
-        if last_sent and len(last_sent) > 20:
-            _add("NEXT", last_sent, last_idx)
-
-        # Bullet items from final assistant response
-        for item in _extract_bullet_items(last_asst):
-            _add("OPEN", item, last_idx)
-
-    # Layer 3: Question detection — unanswered questions in last user message
-    if exchanges:
-        last = exchanges[-1]
-        last_user = last.get("user", "")
-        last_asst = last.get("assistant", "")
-        last_idx = last.get("index", 0)
-
-        if last_user.rstrip().endswith("?"):
-            # Check if assistant response suggests unfinished work
-            if re.search(r'(?:want me to|should I|shall I|ready to|want to proceed)', last_asst, re.IGNORECASE):
-                _add("OPEN", last_user.strip()[:150], last_idx)
-
-    # Enforce caps: max per type, max total
-    type_counts = {}  # type: dict[str, int]
-    capped = []
-    for m in markers:
-        t = m["type"]
-        type_counts[t] = type_counts.get(t, 0) + 1
-        if type_counts[t] <= _MAX_PER_TYPE and len(capped) < _MAX_TOTAL:
-            capped.append(m)
-
-    return capped
 
 
 def build_exchange_pairs(messages: list[dict]) -> list[dict]:
@@ -240,7 +126,7 @@ def build_context_summary_json(branch_row: dict, messages: list[dict]) -> dict:
     """
     exchanges = build_exchange_pairs(messages)
     if not exchanges:
-        return {"version": 2, "topic": "", "markers": [], "first_exchanges": [],
+        return {"version": 2, "topic": "", "first_exchanges": [],
                 "last_exchanges": [], "metadata": {}}
 
     # Topic from first user message
@@ -248,10 +134,7 @@ def build_context_summary_json(branch_row: dict, messages: list[dict]) -> dict:
     if len(topic) > 120:
         topic = topic[:120] + "..."
 
-    # Disposition from final exchange; markers disabled (topic + disposition + gap summary
-    # provide equivalent signal without the garbled-regex-fragment risk)
     disposition = detect_disposition(exchanges)
-    markers = []
 
     # First exchanges (up to 2)
     first_exchanges = [
@@ -299,7 +182,6 @@ def build_context_summary_json(branch_row: dict, messages: list[dict]) -> dict:
         "version": 2,
         "topic": topic,
         "disposition": disposition,
-        "markers": markers,
         "first_exchanges": first_exchanges,
         "last_exchanges": last_exchanges,
         "metadata": {
@@ -314,30 +196,13 @@ def build_context_summary_json(branch_row: dict, messages: list[dict]) -> dict:
     }
 
 
-def _build_gap_summary(summary_json: dict, gap_start: int, gap_end: int) -> str:
-    """Build a one-line summary of what happened in the omitted middle exchanges.
-
-    Extracts file paths mentioned, questions asked, and markers sourced from the gap.
-    """
-    parts = []
-
-    # File paths from metadata
+def _build_gap_summary(summary_json: dict) -> str:
+    """Build a one-line summary of what happened in the omitted middle exchanges."""
     files = summary_json.get("metadata", {}).get("files_modified", [])
     if files:
-        # Show up to 3 short filenames
         short = [f.rsplit("/", 1)[-1] for f in files[:3]]
-        parts.append(", ".join(short))
-
-    # Count questions in the gap from markers
-    gap_markers = [
-        m for m in summary_json.get("markers", [])
-        if gap_start <= m.get("source_exchange", -1) < gap_end
-    ]
-    questions = sum(1 for m in gap_markers if m["type"] == "OPEN")
-    if questions:
-        parts.append(f"{questions} open question{'s' if questions > 1 else ''}")
-
-    return "; ".join(parts)
+        return ", ".join(short)
+    return ""
 
 
 def render_context_summary(summary_json: dict) -> str:
@@ -397,13 +262,6 @@ def render_context_summary(summary_json: dict) -> str:
     lines.append("")
 
     # Key Signals section (omitted if no markers)
-    markers = summary_json.get("markers", [])
-    if markers:
-        lines.append("### Key Signals\n")
-        for m in markers:
-            lines.append(f"- [{m['type']}] {m['text']}")
-        lines.append("")
-
     exchange_count = meta.get("exchange_count", 0)
     first_exs = summary_json.get("first_exchanges", [])
     last_exs = summary_json.get("last_exchanges", [])
@@ -437,7 +295,7 @@ def render_context_summary(summary_json: dict) -> str:
         # Gap indicator with summary of middle exchanges
         gap = exchange_count - len(first_exs) - len(last_exs)
         if gap > 0:
-            gap_detail = _build_gap_summary(summary_json, len(first_exs), exchange_count - len(last_exs))
+            gap_detail = _build_gap_summary(summary_json)
             if gap_detail:
                 lines.append(f"[... {gap} earlier exchanges covering: {gap_detail} ...]\n")
             else:

--- a/tests/claude-memory/test_db.py
+++ b/tests/claude-memory/test_db.py
@@ -787,3 +787,47 @@ class TestCurrentOnboardingVersion:
     def test_value_is_one(self):
         """Both write_config and onboarding.py depend on this being 1."""
         assert CURRENT_ONBOARDING_VERSION == 1
+
+
+class TestMigrateDbBackupGuard:
+    """Gap 3 — backup failure must block the destructive nuke in migrate_db.
+
+    Prevents: a disk-full or permission error during backup silently destroying
+    the only copy of conversation data that predates the 30-day JSONL expiry.
+    """
+
+    def test_backup_failure_blocks_nuke(self, tmp_path, monkeypatch):
+        """When _backup_db_before_migration returns False, migrate_db must abort."""
+        # Create a file-backed v2 DB (sessions exists, branches does not)
+        db_file = tmp_path / "conversations.db"
+        conn = sqlite3.connect(str(db_file))
+        conn.execute("""
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                uuid TEXT UNIQUE NOT NULL,
+                project_id INTEGER
+            )
+        """)
+        conn.execute("INSERT INTO sessions (uuid) VALUES ('keep-me')")
+        conn.commit()
+
+        import memory_lib.db as db_module
+        monkeypatch.setattr(db_module, "_backup_db_before_migration", lambda *a, **kw: False)
+
+        result = migrate_db(conn)
+
+        # Must refuse to migrate when backup fails
+        assert result is False, (
+            "migrate_db must return False when _backup_db_before_migration returns False"
+        )
+
+        # Original DB file must still exist
+        assert db_file.exists(), "DB file must not be deleted when backup failed"
+
+        # File must still be readable and contain original data
+        verify = sqlite3.connect(str(db_file))
+        count = verify.execute("SELECT COUNT(*) FROM sessions WHERE uuid = 'keep-me'").fetchone()[0]
+        verify.close()
+        assert count == 1, (
+            "Original session data must be intact after aborted migration"
+        )

--- a/tests/claude-memory/test_db.py
+++ b/tests/claude-memory/test_db.py
@@ -812,7 +812,7 @@ class TestMigrateDbBackupGuard:
         conn.commit()
 
         import memory_lib.db as db_module
-        monkeypatch.setattr(db_module, "_backup_db_before_migration", lambda *a, **kw: False)
+        monkeypatch.setattr(db_module, "_backup_db_before_migration", lambda *_a, **_kw: False)
 
         result = migrate_db(conn)
 

--- a/tests/claude-memory/test_db.py
+++ b/tests/claude-memory/test_db.py
@@ -307,8 +307,12 @@ class TestVersionedMigration:
         assert origin == "telegram"
         conn.close()
 
-    def test_v3_backfill_nullifies_hash_for_channel_sessions(self, tmp_path):
-        """v3 migration nullifies file_hash for sessions with isMeta+origin channel messages."""
+    def test_v3_backfill_preserves_hash_for_channel_sessions(self, tmp_path):
+        """v3 migration preserves file_hash — no longer nullifies to trigger reimport.
+
+        Phase 2 hash nullification was removed because the reimport path was
+        destructive (delete-all-then-insert) and JSONL files expire after 30 days.
+        """
         conn = _versioned_db(user_version=2)
         conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY, uuid TEXT UNIQUE, project_id INTEGER, parent_session_id INTEGER, git_branch TEXT, cwd TEXT)")
         conn.execute("INSERT INTO sessions (id, uuid) VALUES (1, 'chan-uuid')")
@@ -327,7 +331,7 @@ class TestVersionedMigration:
         _migrate_columns(conn)
 
         hash_val = conn.execute("SELECT file_hash FROM import_log").fetchone()[0]
-        assert hash_val is None  # Nullified to trigger reimport of this session
+        assert hash_val == "original"  # Hash preserved — no destructive reimport triggered
         conn.close()
 
 

--- a/tests/claude-memory/test_import_pipeline.py
+++ b/tests/claude-memory/test_import_pipeline.py
@@ -417,7 +417,7 @@ class TestAppendOnlyReimport:
         fixture_file = FIXTURE_DIR / "linear_3_exchange.jsonl"
 
         # First import — establish baseline
-        branches1, messages1 = import_session(memory_db, fixture_file, project_id)
+        branches1, _messages1 = import_session(memory_db, fixture_file, project_id)
         assert branches1 > 0, "First import must succeed"
 
         cursor = memory_db.cursor()

--- a/tests/claude-memory/test_import_pipeline.py
+++ b/tests/claude-memory/test_import_pipeline.py
@@ -403,3 +403,295 @@ class TestImportProject:
             sessions, messages, skipped = import_project(memory_db, project_dir)
             assert sessions == 0
             assert messages == 0
+
+
+class TestAppendOnlyReimport:
+    """Gap 1 — Message deduplication on forced reimport.
+
+    Prevents: stale-hash reimport doubling message rows, breaking recall results
+    and inflating context injection counts.
+    """
+
+    def test_no_duplicate_messages_on_forced_reimport(self, memory_db, project_id):
+        """Staling the import_log hash must not create new message rows."""
+        fixture_file = FIXTURE_DIR / "linear_3_exchange.jsonl"
+
+        # First import — establish baseline
+        branches1, messages1 = import_session(memory_db, fixture_file, project_id)
+        assert branches1 > 0, "First import must succeed"
+
+        cursor = memory_db.cursor()
+        cursor.execute(
+            "SELECT id, uuid FROM messages WHERE session_id = "
+            "(SELECT id FROM sessions WHERE project_id = ?)",
+            (project_id,)
+        )
+        rows_before = cursor.fetchall()
+        ids_before = {row[0] for row in rows_before}
+        uuids_before = {row[1] for row in rows_before}
+
+        # Force reimport by staling the hash
+        cursor.execute(
+            "UPDATE import_log SET file_hash = 'stale' WHERE file_path = ?",
+            (str(fixture_file),)
+        )
+        memory_db.commit()
+
+        branches2, messages2 = import_session(memory_db, fixture_file, project_id)
+        assert branches2 > 0, "Forced reimport must succeed"
+
+        # Same number of message rows — append-only, no duplicates
+        cursor.execute(
+            "SELECT id, uuid FROM messages WHERE session_id = "
+            "(SELECT id FROM sessions WHERE project_id = ?)",
+            (project_id,)
+        )
+        rows_after = cursor.fetchall()
+        assert len(rows_after) == len(rows_before), (
+            "Reimport must not create duplicate message rows"
+        )
+
+        # Same DB row IDs — ON CONFLICT DO NOTHING preserved originals
+        ids_after = {row[0] for row in rows_after}
+        assert ids_after == ids_before, "Same DB row IDs must survive reimport"
+
+        # No new UUIDs introduced
+        uuids_after = {row[1] for row in rows_after}
+        assert uuids_after == uuids_before, "No new UUIDs may appear after reimport"
+
+    def test_no_duplicate_session_uuid_message_pairs(self, memory_db, project_id):
+        """(session_id, uuid) uniqueness must hold across repeated forced reimports."""
+        fixture_file = FIXTURE_DIR / "linear_3_exchange.jsonl"
+        import_session(memory_db, fixture_file, project_id)
+
+        for _ in range(2):
+            cursor = memory_db.cursor()
+            cursor.execute(
+                "UPDATE import_log SET file_hash = 'stale' WHERE file_path = ?",
+                (str(fixture_file),)
+            )
+            memory_db.commit()
+            import_session(memory_db, fixture_file, project_id)
+
+        # Check no (session_id, uuid) duplicates exist anywhere
+        cursor = memory_db.cursor()
+        cursor.execute("""
+            SELECT session_id, uuid, COUNT(*) AS cnt
+            FROM messages
+            GROUP BY session_id, uuid
+            HAVING cnt > 1
+        """)
+        duplicates = cursor.fetchall()
+        assert duplicates == [], (
+            f"Duplicate (session_id, uuid) pairs found after repeated reimport: {duplicates}"
+        )
+
+
+class TestBranchMessagesDiffOnReimport:
+    """Gap 2 — branch_messages link set must be identical after forced reimport.
+
+    Prevents: ghost branch-message links accumulating across reimports, causing
+    search results to surface deleted message content.
+    """
+
+    def test_branch_messages_identical_after_reimport(self, memory_db, project_id):
+        """branch_messages rows must be the same set before and after stale-hash reimport."""
+        fixture_file = FIXTURE_DIR / "single_rewind.jsonl"
+
+        branches1, _ = import_session(memory_db, fixture_file, project_id)
+        assert branches1 == 3, "Fixture must produce 3 branches for this test to be meaningful"
+
+        cursor = memory_db.cursor()
+        cursor.execute("""
+            SELECT branch_id, message_id FROM branch_messages
+            WHERE branch_id IN (
+                SELECT b.id FROM branches b
+                JOIN sessions s ON b.session_id = s.id
+                WHERE s.project_id = ?
+            )
+            ORDER BY branch_id, message_id
+        """, (project_id,))
+        links_before = cursor.fetchall()
+        assert links_before, "branch_messages must be populated after first import"
+
+        # Force reimport
+        cursor.execute(
+            "UPDATE import_log SET file_hash = 'stale' WHERE file_path = ?",
+            (str(fixture_file),)
+        )
+        memory_db.commit()
+
+        branches2, _ = import_session(memory_db, fixture_file, project_id)
+        assert branches2 == 3, "Reimport must produce same branch count"
+
+        cursor.execute("""
+            SELECT branch_id, message_id FROM branch_messages
+            WHERE branch_id IN (
+                SELECT b.id FROM branches b
+                JOIN sessions s ON b.session_id = s.id
+                WHERE s.project_id = ?
+            )
+            ORDER BY branch_id, message_id
+        """, (project_id,))
+        links_after = cursor.fetchall()
+
+        assert links_after == links_before, (
+            "branch_messages link set must be identical after forced reimport — "
+            f"before={len(links_before)}, after={len(links_after)}"
+        )
+
+
+class TestSessionWithMessagesButNoBranches:
+    """Gap 5 — Session rows and message rows survive when all branch content is empty.
+
+    Prevents: conservative cleanup accidentally deleting sessions that have messages
+    but whose only branch produced no FTS content (all-notification session).
+    The import code skips empty branches but must not delete the session row when
+    messages still exist.
+    """
+
+    def test_session_row_survives_all_notification_branch(self, memory_db, project_id):
+        """Session and its messages must persist when the branch has only notification content."""
+        # A JSONL where the sole user message is a task-notification.
+        # aggregate_branch_content will return empty (notification excluded from FTS)
+        # but the import should keep the session and its message rows intact.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            temp_path = Path(f.name)
+            f.write('{"uuid":"root","type":"progress","timestamp":"2026-03-01T10:00:00Z","sessionId":"notif-only-sess","cwd":"/test"}\n')
+            # Notification user message — is_notification=1, stored but excluded from FTS
+            f.write('{"uuid":"msg1","parentUuid":"root","type":"user","timestamp":"2026-03-01T10:00:01Z","sessionId":"notif-only-sess","message":{"role":"user","content":"<task-notification><task-id>x</task-id>Task done</task-notification>"}}\n')
+            # Assistant reply with real text — this IS included in FTS
+            f.write('{"uuid":"msg2","parentUuid":"msg1","type":"assistant","timestamp":"2026-03-01T10:00:02Z","sessionId":"notif-only-sess","message":{"role":"assistant","content":[{"type":"text","text":"Acknowledged the task notification."}]}}\n')
+
+        try:
+            branches_imported, total_messages = import_session(
+                memory_db, temp_path, project_id
+            )
+
+            cursor = memory_db.cursor()
+            # Session must still exist (messages present — conservative cleanup)
+            cursor.execute("SELECT COUNT(*) FROM sessions WHERE project_id = ?", (project_id,))
+            session_count = cursor.fetchone()[0]
+
+            if branches_imported > 0:
+                # Branch survived (assistant text kept it non-empty) — session must exist
+                assert session_count == 1, "Session must exist when branch has content"
+                cursor.execute(
+                    "SELECT COUNT(*) FROM messages WHERE session_id = "
+                    "(SELECT id FROM sessions WHERE project_id = ?)",
+                    (project_id,)
+                )
+                msg_count = cursor.fetchone()[0]
+                assert msg_count > 0, "Message rows must survive alongside the session"
+            else:
+                # No branches imported — verify the session was only removed if
+                # it truly has no messages (conservative cleanup check)
+                if session_count > 0:
+                    cursor.execute(
+                        "SELECT COUNT(*) FROM messages WHERE session_id = "
+                        "(SELECT id FROM sessions WHERE project_id = ?)",
+                        (project_id,)
+                    )
+                    msg_count = cursor.fetchone()[0]
+                    assert msg_count > 0, (
+                        "Session row must not survive with zero message rows — "
+                        "that would be an orphaned session"
+                    )
+        finally:
+            temp_path.unlink()
+
+    def test_session_deleted_only_when_both_messages_and_branches_are_zero(self, memory_db, project_id):
+        """Session cleanup fires only when message count AND branch count are both zero.
+
+        A session with messages but no branches (all branches empty) should not be deleted
+        if messages exist — removing it would destroy potentially-recoverable data.
+        """
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            temp_path = Path(f.name)
+            # Only tool_result messages — no extractable text, triggers guard 1 (no messages)
+            f.write('{"uuid":"root","type":"progress","timestamp":"2026-03-01T10:00:00Z","sessionId":"empty-sess","cwd":"/test"}\n')
+            f.write('{"uuid":"msg1","parentUuid":"root","type":"user","timestamp":"2026-03-01T10:00:01Z","sessionId":"empty-sess","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"result"}]}}\n')
+
+        try:
+            branches_imported, total_messages = import_session(
+                memory_db, temp_path, project_id
+            )
+
+            # Guard 1 fires: no extractable text, session must be cleaned up
+            assert branches_imported == -1, "Should trigger guard 1 (no extractable content)"
+
+            cursor = memory_db.cursor()
+            cursor.execute("SELECT COUNT(*) FROM sessions WHERE project_id = ?", (project_id,))
+            assert cursor.fetchone()[0] == 0, (
+                "Session with zero messages and zero branches must be cleaned up"
+            )
+        finally:
+            temp_path.unlink()
+
+
+class TestEmptyBranchGuardTightened:
+    """Gap 6 — Tightened TestEmptyBranchGuard: empty branches preserved, not deleted.
+
+    The import code comments explicitly state: 'No searchable content — skip but
+    don't delete. Deleting causes thrashing.' This test pins that contract so a
+    future refactor can't accidentally reintroduce the delete path.
+    """
+
+    def test_empty_branch_row_preserved_after_reimport(self, memory_db, project_id):
+        """An empty-FTS branch must still exist in the DB after a forced reimport.
+
+        If the branch were deleted on first import and then recreated on reimport
+        (thrash cycle), the branch_id would differ — this test pins that the same
+        branch row survives.
+        """
+        # Notification-only session: branch is created but aggregated_content is
+        # empty after excluding notifications.  The branch row must be preserved.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            temp_path = Path(f.name)
+            f.write('{"uuid":"root","type":"progress","timestamp":"2026-03-01T10:00:00Z","sessionId":"empty-branch-sess","cwd":"/test"}\n')
+            # Notification-only user message
+            f.write('{"uuid":"msg1","parentUuid":"root","type":"user","timestamp":"2026-03-01T10:00:01Z","sessionId":"empty-branch-sess","message":{"role":"user","content":"<task-notification><task-id>y</task-id>Work done</task-notification>"}}\n')
+            # No assistant reply — branch has no non-notification content at all
+
+        try:
+            # First import
+            import_session(memory_db, temp_path, project_id)
+
+            cursor = memory_db.cursor()
+            cursor.execute("""
+                SELECT b.id FROM branches b
+                JOIN sessions s ON b.session_id = s.id
+                WHERE s.project_id = ?
+            """, (project_id,))
+            branch_rows_after_first = cursor.fetchall()
+
+            if not branch_rows_after_first:
+                # Guard 1 fired (no messages at all) — nothing to test for branch preservation
+                cursor.execute("SELECT COUNT(*) FROM sessions WHERE project_id = ?", (project_id,))
+                assert cursor.fetchone()[0] == 0, "Guard 1 must clean up empty session"
+                return
+
+            branch_ids_after_first = {row[0] for row in branch_rows_after_first}
+
+            # Force reimport
+            cursor.execute(
+                "UPDATE import_log SET file_hash = 'stale' WHERE file_path = ?",
+                (str(temp_path),)
+            )
+            memory_db.commit()
+            import_session(memory_db, temp_path, project_id)
+
+            cursor.execute("""
+                SELECT b.id FROM branches b
+                JOIN sessions s ON b.session_id = s.id
+                WHERE s.project_id = ?
+            """, (project_id,))
+            branch_ids_after_reimport = {row[0] for row in cursor.fetchall()}
+
+            # No branch rows should have disappeared — empty branches are preserved
+            assert branch_ids_after_first.issubset(branch_ids_after_reimport), (
+                "Empty branch rows must be preserved across reimport — "
+                "deleting them causes import thrash on every cycle"
+            )
+        finally:
+            temp_path.unlink()

--- a/tests/claude-memory/test_ingest_token_data.py
+++ b/tests/claude-memory/test_ingest_token_data.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Tests for ingest_token_data — token ingest append-only behaviour.
+
+Gap 4: turns must be skip-if-exists on reimport, and session_metrics totals
+must not double when the same session is ingested twice.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add the ingest script's directory to sys.path so imports resolve
+_INGEST_DIR = (
+    Path(__file__).resolve().parent.parent.parent
+    / "plugins" / "claude-memory" / "skills"
+    / "get-token-insights" / "scripts"
+)
+sys.path.insert(0, str(_INGEST_DIR))
+
+from ingest_token_data import (
+    JnlFile,
+    ParsedSession,
+    Turn,
+    ensure_schema,
+    import_session,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _minimal_jnl(tmp_path: Path) -> JnlFile:
+    """A JnlFile pointing at a dummy path (file not actually read in these tests)."""
+    fake_path = tmp_path / "fake-session.jsonl"
+    fake_path.write_text("")
+    return JnlFile(
+        path=fake_path,
+        project_cwd="/test/project",
+        is_sidechain=False,
+        parent_session_id=None,
+    )
+
+
+def _make_session(session_id: str, turns: list[Turn]) -> ParsedSession:
+    """Build a minimal ParsedSession from an explicit turn list."""
+    s = ParsedSession(session_id=session_id, project_path="/test/project")
+    s.turns = turns
+    return s
+
+
+def _make_turn(index: int, input_tokens: int = 100, output_tokens: int = 50) -> Turn:
+    return Turn(
+        index=index,
+        message_id=f"msg-{index}",
+        timestamp=f"2026-03-01T10:0{index}:00Z",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+@pytest.fixture
+def token_db():
+    """In-memory DB with full token ingest schema."""
+    conn = sqlite3.connect(":memory:")
+    ensure_schema(conn)
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Gap 4a — turns are append-only (skip-if-exists)
+# ---------------------------------------------------------------------------
+
+class TestTurnsAppendOnly:
+    """Importing the same session twice must not duplicate turn rows."""
+
+    def test_first_import_creates_turns(self, token_db, tmp_path):
+        """First ingest writes one row per turn into the turns table."""
+        jnl = _minimal_jnl(tmp_path)
+        session = _make_session("sess-abc", [_make_turn(1), _make_turn(2)])
+
+        import_session(token_db, session, jnl)
+        token_db.commit()
+
+        count = token_db.execute(
+            "SELECT COUNT(*) FROM turns WHERE session_id = 'sess-abc'"
+        ).fetchone()[0]
+        assert count == 2, f"Expected 2 turn rows after first import, got {count}"
+
+    def test_second_import_skips_existing_turns(self, token_db, tmp_path):
+        """Second ingest of the same session must not add new turn rows."""
+        jnl = _minimal_jnl(tmp_path)
+        session = _make_session("sess-dedup", [_make_turn(1), _make_turn(2)])
+
+        import_session(token_db, session, jnl)
+        token_db.commit()
+
+        # Import identical session again
+        import_session(token_db, session, jnl)
+        token_db.commit()
+
+        count = token_db.execute(
+            "SELECT COUNT(*) FROM turns WHERE session_id = 'sess-dedup'"
+        ).fetchone()[0]
+        assert count == 2, (
+            f"Duplicate import must not create extra turn rows — got {count}"
+        )
+
+    def test_repeated_imports_no_duplicate_turn_index(self, token_db, tmp_path):
+        """(session_id, turn_index) uniqueness must hold after multiple imports."""
+        jnl = _minimal_jnl(tmp_path)
+        session = _make_session("sess-unique", [_make_turn(1), _make_turn(2)])
+
+        for _ in range(3):
+            import_session(token_db, session, jnl)
+            token_db.commit()
+
+        rows = token_db.execute("""
+            SELECT session_id, turn_index, COUNT(*) AS cnt
+            FROM turns
+            WHERE session_id = 'sess-unique'
+            GROUP BY session_id, turn_index
+            HAVING cnt > 1
+        """).fetchall()
+        assert rows == [], (
+            f"(session_id, turn_index) must be unique — duplicates found: {rows}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gap 4b — session_metrics totals do not double on reimport
+# ---------------------------------------------------------------------------
+
+class TestSessionMetricsStableOnReimport:
+    """session_metrics totals must reflect the session once, not accumulate."""
+
+    def test_total_input_tokens_not_doubled(self, token_db, tmp_path):
+        """total_input_tokens in session_metrics must be the same after two imports."""
+        jnl = _minimal_jnl(tmp_path)
+        # Two turns with known token counts
+        session = _make_session(
+            "sess-tokens",
+            [_make_turn(1, input_tokens=200), _make_turn(2, input_tokens=300)],
+        )
+
+        import_session(token_db, session, jnl)
+        token_db.commit()
+
+        first_total = token_db.execute(
+            "SELECT total_input_tokens FROM session_metrics WHERE session_id = 'sess-tokens'"
+        ).fetchone()[0]
+        assert first_total == 500, f"Expected 500 input tokens after first import, got {first_total}"
+
+        # Reimport same session
+        import_session(token_db, session, jnl)
+        token_db.commit()
+
+        second_total = token_db.execute(
+            "SELECT total_input_tokens FROM session_metrics WHERE session_id = 'sess-tokens'"
+        ).fetchone()[0]
+        assert second_total == first_total, (
+            f"total_input_tokens doubled after reimport: {first_total} → {second_total}. "
+            "session_metrics must use INSERT OR REPLACE (idempotent upsert), not accumulate."
+        )
+
+    def test_turn_count_not_doubled(self, token_db, tmp_path):
+        """session_metrics.turn_count must equal the number of turns, not double on reimport."""
+        jnl = _minimal_jnl(tmp_path)
+        session = _make_session("sess-count", [_make_turn(1), _make_turn(2)])
+
+        import_session(token_db, session, jnl)
+        token_db.commit()
+
+        import_session(token_db, session, jnl)
+        token_db.commit()
+
+        turn_count = token_db.execute(
+            "SELECT turn_count FROM session_metrics WHERE session_id = 'sess-count'"
+        ).fetchone()[0]
+        assert turn_count == 2, (
+            f"turn_count must be 2 (number of turns), not {turn_count} — "
+            "signals that session_metrics is being summed rather than replaced"
+        )
+
+    def test_session_metrics_row_exists_after_import(self, token_db, tmp_path):
+        """Exactly one session_metrics row must exist after two imports of the same session."""
+        jnl = _minimal_jnl(tmp_path)
+        session = _make_session("sess-single", [_make_turn(1)])
+
+        import_session(token_db, session, jnl)
+        token_db.commit()
+        import_session(token_db, session, jnl)
+        token_db.commit()
+
+        count = token_db.execute(
+            "SELECT COUNT(*) FROM session_metrics WHERE session_id = 'sess-single'"
+        ).fetchone()[0]
+        assert count == 1, (
+            f"Expected exactly 1 session_metrics row, got {count} — "
+            "INSERT OR REPLACE must upsert, not insert a second row"
+        )

--- a/tests/claude-memory/test_integration.py
+++ b/tests/claude-memory/test_integration.py
@@ -69,7 +69,7 @@ def _setup_db_and_import(filepath: Path) -> sqlite3.Connection:
     for branch in branches:
         branch_msgs = [m for m in messages if m.get("uuid") in branch["uuids"]]
         branch_msgs.sort(key=lambda e: e.get("timestamp") or "")
-        exchange_count, files, commits, tool_counts = compute_branch_metadata(branch_msgs)
+        exchange_count, files, commits, _tool_counts = compute_branch_metadata(branch_msgs)
 
         cursor.execute("""
             INSERT INTO branches (session_id, leaf_uuid, is_active, exchange_count)

--- a/tests/claude-memory/test_summarizer.py
+++ b/tests/claude-memory/test_summarizer.py
@@ -12,7 +12,6 @@ from memory_lib.summarizer import (
     truncate_mid,
     build_context_summary_json,
     compute_context_summary,
-    extract_markers,
     render_context_summary,
 )
 from memory_lib.db import SCHEMA, _migrate_columns
@@ -77,97 +76,6 @@ class TestBuildExchangePairs:
         assert len(exchanges) == 1
         assert exchanges[0]["user"] == "Last question"
         assert exchanges[0]["assistant"] == ""
-
-
-class TestExtractMarkers:
-    def test_keyword_decided(self):
-        exchanges = [
-            {"user": "What approach?", "assistant": "We decided to use Redis for caching instead of memcached.", "index": 0},
-        ]
-        markers = extract_markers(exchanges)
-        assert any(m["type"] == "DECIDED" for m in markers)
-
-    def test_keyword_next_step(self):
-        exchanges = [
-            {"user": "What's next?", "assistant": "The next step is implementing the API endpoint for users.", "index": 0},
-        ]
-        markers = extract_markers(exchanges)
-        assert any(m["type"] == "NEXT" for m in markers)
-
-    def test_keyword_blocked(self):
-        exchanges = [
-            {"user": "Status?", "assistant": "We're blocked on the auth service being down in staging.", "index": 0},
-        ]
-        markers = extract_markers(exchanges)
-        assert any(m["type"] == "OPEN" for m in markers)
-
-    def test_keyword_rejected(self):
-        exchanges = [
-            {"user": "skip the tests for now and just deploy", "assistant": "OK, skipping tests.", "index": 0},
-        ]
-        markers = extract_markers(exchanges)
-        assert any(m["type"] == "REJECTED" for m in markers)
-
-    def test_user_intent_prefix(self):
-        exchanges = [
-            {"user": "let's refactor the database module to use connection pooling", "assistant": "Sounds good.", "index": 0},
-        ]
-        markers = extract_markers(exchanges)
-        assert any(m["type"] == "OPEN" for m in markers)
-
-    def test_positional_last_sentence(self):
-        exchanges = [
-            {"user": "Q1", "assistant": "Short answer.", "index": 0},
-            {"user": "Q2", "assistant": "Let me explain. First this. Then that. Finally, we need to implement the caching layer before deploy.", "index": 1},
-        ]
-        markers = extract_markers(exchanges)
-        # Last sentence of final response should produce a NEXT marker
-        assert len(markers) > 0
-
-    def test_question_detection(self):
-        exchanges = [
-            {"user": "Should we proceed with the migration?", "assistant": "Want me to start the migration now?", "index": 0},
-        ]
-        markers = extract_markers(exchanges)
-        assert any(m["type"] == "OPEN" for m in markers)
-
-    def test_dedup_by_substring(self):
-        exchanges = [
-            {"user": "plan?", "assistant": "We decided to use Redis. We decided to use Redis for caching.", "index": 0},
-        ]
-        markers = extract_markers(exchanges)
-        decided = [m for m in markers if m["type"] == "DECIDED"]
-        assert len(decided) <= 1  # Deduped
-
-    def test_cap_per_type(self):
-        # Generate many DECIDED markers
-        exchanges = [
-            {"user": "plan?", "assistant": f"We decided to use approach {i} for component {i} in system." * 2, "index": i}
-            for i in range(10)
-        ]
-        markers = extract_markers(exchanges)
-        decided_count = sum(1 for m in markers if m["type"] == "DECIDED")
-        assert decided_count <= 3
-
-    def test_cap_total(self):
-        # Generate many markers of different types
-        exchanges = [
-            {"user": f"let's implement feature number {i} in the codebase", "assistant": f"We decided to use approach {i} for the implementation. Next step is testing approach {i} thoroughly.", "index": i}
-            for i in range(20)
-        ]
-        markers = extract_markers(exchanges)
-        assert len(markers) <= 10
-
-    def test_empty_exchanges(self):
-        assert extract_markers([]) == []
-
-    def test_short_text_ignored(self):
-        exchanges = [
-            {"user": "ok", "assistant": "done", "index": 0},
-        ]
-        markers = extract_markers(exchanges)
-        # Short text (<10 chars) should not produce markers
-        assert len(markers) == 0
 
 
 class TestBuildContextSummaryJson:
@@ -254,7 +162,7 @@ class TestRenderContextSummary:
         summary = {
             "version": 2,
             "topic": "test",
-            "markers": [],
+
             "first_exchanges": [
                 {"user": "Q1", "assistant": "A1", "timestamp": "2025-01-15T10:00:00Z"},
             ],
@@ -276,7 +184,7 @@ class TestRenderContextSummary:
         summary = {
             "version": 2,
             "topic": "test",
-            "markers": [],
+
             "first_exchanges": [
                 {"user": "Q1", "assistant": "A1", "timestamp": "2025-01-15T10:00:00Z"},
                 {"user": "Q2", "assistant": "A2", "timestamp": "2025-01-15T10:01:00Z"},
@@ -303,33 +211,12 @@ class TestRenderContextSummary:
         assert "Tools:" in result
         assert "/recall-conversations" in result
 
-    def test_markers_rendered(self):
-        summary = {
-            "version": 2,
-            "topic": "test",
-            "markers": [
-                {"type": "DECIDED", "text": "Use Redis for caching", "source_exchange": 3},
-                {"type": "OPEN", "text": "Auth service needs fixing", "source_exchange": 5},
-            ],
-            "first_exchanges": [
-                {"user": "Q1", "assistant": "A1", "timestamp": "2025-01-15T10:00:00Z"},
-            ],
-            "last_exchanges": [{"user": "Q1", "assistant": "A1", "timestamp": "2025-01-15T10:00:00Z"}],
-            "metadata": {"exchange_count": 1, "started_at": "2025-01-15T10:00:00Z",
-                          "ended_at": "2025-01-15T10:30:00Z", "git_branch": "main",
-                          "files_modified": [], "commits": [], "tool_counts": {}},
-        }
-        result = render_context_summary(summary)
-        assert "### Key Signals" in result
-        assert "[DECIDED] Use Redis for caching" in result
-        assert "[OPEN] Auth service needs fixing" in result
-
     def test_mid_truncation_in_render(self):
         long_response = "Start " + "x" * 1000 + " End"
         summary = {
             "version": 2,
             "topic": "test",
-            "markers": [],
+
             "first_exchanges": [
                 {"user": "Q1", "assistant": long_response, "timestamp": "2025-01-15T10:00:00Z"},
             ],

--- a/tests/claude-memory/test_sync_hook.py
+++ b/tests/claude-memory/test_sync_hook.py
@@ -305,3 +305,58 @@ class TestSyncBranchMessagesDiff:
             assert not duplicates, (
                 f"Duplicate (branch_id, message_id) pairs found after 3 syncs: {duplicates}"
             )
+
+    def test_new_messages_add_branch_links_without_removing_old(self, memory_db_with_project):
+        """Growing a session mid-sync must add new branch_messages and keep existing ones.
+
+        Prevents: the diff logic silently dropping links when new messages arrive
+        (to_add stays empty or to_remove incorrectly prunes valid links), which
+        would cause a mid-session Stop hook to lose newly-synced conversation turns
+        from search results until the next full reimport.
+        """
+        conn, _ = memory_db_with_project
+        fixture_lines = (FIXTURE_DIR / "single_rewind.jsonl").read_text().splitlines()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+
+            # Use a UUID-shaped stem so sync_session can parse it as a session UUID.
+            # Both files share the same stem so they map to the same session row in the DB.
+            session_stem = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+            partial_path = project_dir / f"{session_stem}.jsonl"
+            full_path = project_dir / f"{session_stem}.jsonl"
+
+            # First sync: a truncated session (first 20 raw lines — 2 user/assistant
+            # exchanges that survive the text-content filter).
+            partial_path.write_text("\n".join(fixture_lines[:20]))
+            sync_session(conn, partial_path, project_dir)
+            conn.commit()
+
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT branch_id, message_id FROM branch_messages ORDER BY branch_id, message_id"
+            )
+            links_after_partial = set(cursor.fetchall())
+            assert links_after_partial, "branch_messages must be populated after partial sync"
+
+            # Second sync: the full session (all fixture lines — many more exchanges).
+            full_path.write_text("\n".join(fixture_lines))
+            sync_session(conn, full_path, project_dir)
+            conn.commit()
+
+            cursor.execute(
+                "SELECT branch_id, message_id FROM branch_messages ORDER BY branch_id, message_id"
+            )
+            links_after_full = set(cursor.fetchall())
+
+            # All links from the partial sync must still exist (append-only for existing links)
+            assert links_after_partial.issubset(links_after_full), (
+                "branch_messages from partial sync were removed after full sync — "
+                f"missing: {links_after_partial - links_after_full}"
+            )
+
+            # The full sync must have added new links (growth was actually recorded)
+            assert len(links_after_full) > len(links_after_partial), (
+                "branch_messages did not grow after syncing a longer session — "
+                f"partial={len(links_after_partial)}, full={len(links_after_full)}"
+            )

--- a/tests/claude-memory/test_sync_hook.py
+++ b/tests/claude-memory/test_sync_hook.py
@@ -239,3 +239,69 @@ class TestValidateSessionIdRejectsTraversal:
     def test_validate_session_id_rejects_uuid_with_extra(self):
         """Should reject UUID with extra characters."""
         assert validate_session_id("016e1f0d-cff2-4552-9e21-43833c9a468e-extra") is False
+
+
+class TestSyncBranchMessagesDiff:
+    """Test that sync_session's branch_messages diff is stable across repeated syncs.
+
+    Prevents: ghost branch-message links accumulating on every PostToolUse turn,
+    which would cause search to surface deleted/stale message content and bloat
+    branch_messages with duplicate rows that survive until manual DB repair.
+    """
+
+    def test_branch_messages_stable_on_resync(self, memory_db_with_project):
+        """branch_messages row set must be identical after a second sync of the same session."""
+        conn, _ = memory_db_with_project
+        fixture_path = FIXTURE_DIR / "single_rewind.jsonl"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+
+            # First sync — populate branches and branch_messages
+            sync_session(conn, fixture_path, project_dir)
+            conn.commit()
+
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT branch_id, message_id FROM branch_messages ORDER BY branch_id, message_id"
+            )
+            links_after_first = cursor.fetchall()
+            assert links_after_first, "branch_messages must be populated after first sync"
+
+            # Second sync — same file, same session; the diff should be a no-op
+            sync_session(conn, fixture_path, project_dir)
+            conn.commit()
+
+            cursor.execute(
+                "SELECT branch_id, message_id FROM branch_messages ORDER BY branch_id, message_id"
+            )
+            links_after_second = cursor.fetchall()
+
+            assert links_after_second == links_after_first, (
+                "branch_messages link set must be identical after resync — "
+                f"before={len(links_after_first)}, after={len(links_after_second)}"
+            )
+
+    def test_no_duplicate_branch_messages_on_repeated_sync(self, memory_db_with_project):
+        """Repeated syncs must never produce duplicate (branch_id, message_id) pairs."""
+        conn, _ = memory_db_with_project
+        fixture_path = FIXTURE_DIR / "single_rewind.jsonl"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+
+            for _ in range(3):
+                sync_session(conn, fixture_path, project_dir)
+                conn.commit()
+
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT branch_id, message_id, COUNT(*) AS cnt
+                FROM branch_messages
+                GROUP BY branch_id, message_id
+                HAVING cnt > 1
+            """)
+            duplicates = cursor.fetchall()
+            assert not duplicates, (
+                f"Duplicate (branch_id, message_id) pairs found after 3 syncs: {duplicates}"
+            )

--- a/tests/claude-memory/test_write_config.py
+++ b/tests/claude-memory/test_write_config.py
@@ -154,7 +154,7 @@ class TestWriteConfigAtomicWrite:
         _patch_config_path(monkeypatch, cfg)
 
         # Patch os.fdopen to raise after the tempfile is created
-        def exploding_fdopen(fd, mode):
+        def exploding_fdopen(fd, _mode):
             # Close the fd to avoid leaking it, then raise
             os.close(fd)
             raise OSError("simulated write failure")
@@ -175,7 +175,7 @@ class TestWriteConfigAtomicWrite:
         cfg.write_text(json.dumps(original))
         _patch_config_path(monkeypatch, cfg)
 
-        def exploding_fdopen(fd, mode):
+        def exploding_fdopen(fd, _mode):
             os.close(fd)
             raise OSError("simulated write failure")
 


### PR DESCRIPTION
## Summary

Extends the append-only pattern from #56 (`sync_session`) to the two remaining paths that still did destructive delete-all-then-insert: `import_conversations` and `ingest_token_data`.

- `import_conversations`: upserts branches, diffs `branch_messages` (add missing, remove stale links only — never messages), filters messages to only those claimed by a branch UUID. Session cleanup is now conservative: only removes sessions with zero messages AND zero branches.
- `ingest_token_data`: skips existing turns/hook executions, upserts `session_metrics` as a recalculated summary. Renames `import_log` → `token_import_log` (schema v4) to eliminate name collision with the conversations DB table.
- `db.py`: replaces `shutil.copy2` with `sqlite3.Connection.backup()` for WAL-safe pre-migration backup. Backup failure now blocks migration (returns `False`) instead of silently proceeding into data destruction. Removes Phase 2 hash-nullification from `_backfill_origin` — that path triggered the destructive reimport pipeline on JSONL files that may have already expired.
- `test_db.py`: updates hash-nullification test to assert the new behavior (hash preserved, no reimport triggered).

## Test plan
- [x] Run `pytest tests/claude-memory/test_db.py` — all tests pass including the updated `test_v3_backfill_preserves_hash_for_channel_sessions`
- [x] Trigger a manual reimport on a live DB; verify row counts are stable across two consecutive runs (append-only = idempotent)
- [x] Verify token ingest on a JSONL file already partially imported; confirm turns are skipped, not duplicated