### PR TITLE
fix(coding): clean-branches safe worktree handling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.37",
+      "version": "0.2.38",
       "source": "./plugins/claude-coding"
     },
     {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.37](https://img.shields.io/badge/v0.2.37-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.38](https://img.shields.io/badge/v0.2.38-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.37](https://img.shields.io/badge/v0.2.37-blue?style=flat-square)
+# claude-coding ![v0.2.38](https://img.shields.io/badge/v0.2.38-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/skills/clean-branches/SKILL.md
+++ b/plugins/claude-coding/skills/clean-branches/SKILL.md
@@ -4,7 +4,7 @@ description: >
   This skill should be used when the user says "clean up branches", "delete merged
   branches", "prune stale branches", "git branch cleanup", "remove old branches",
   or wants to tidy up or purge old branches.
-argument-hint: "[branch-pattern] - optional pattern to filter branches"
+argument-hint: "[branch-pattern]"
 allowed-tools:
   - Bash(git:*)
   - Bash(bash:*)
@@ -32,31 +32,47 @@ Run the candidate detection script, passing the optional pattern filter:
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/skills/clean-branches/scripts/find-candidates.sh "$PATTERN"
 ```
-The script outputs two labeled sections (`=== MERGED ===` and `=== STALE ===`), one branch per line. Merged branches checked out in a worktree are annotated: `branch-name [worktree:/path/to/wt]`. Parse each section into its own list, preserving the worktree annotation for use in Step 5.
+The script outputs two labeled sections (`=== MERGED ===` and `=== STALE ===`), one branch per line. Branches checked out in a worktree are annotated: `branch-name [worktree:/path/to/wt]`. Parse each section into its own list, preserving the worktree annotation.
+
+After parsing, apply these worktree rules before building the candidate lists:
+
+- **Stale branch + active worktree** → move immediately to the **blocked** list, regardless of worktree state. A stale branch with a live worktree may still have in-progress work — never offer it for cleanup.
+- **Merged branch + active worktree** → check whether the worktree is clean:
+  ```bash
+  git -C /path/to/wt status --porcelain
+  ```
+  If the command returns any output (uncommitted changes), move to the **blocked** list. If clean, keep in the merged candidate list with the worktree annotation.
 
 **3. Present results**
 
-Display branches in three groups: merged (safe to delete), stale (no recent commits), and protected (never touch). If a merged branch carries a worktree annotation, note it with "(active worktree — will be removed first)" so the user understands what will happen. If both candidate lists are empty, report "No branches to clean" and stop — do not proceed to Step 4.
+Display branches in four groups:
+- **Merged** (safe to delete) — branches fully merged into base; those with a clean worktree show "(+ worktree at /path)"
+- **Stale** (no recent commits, no active worktree) — only branches without a worktree appear here
+- **Protected** (never touch) — main, master, develop, release/*
+- **Blocked** — branches skipped because they have an active worktree with uncommitted work, or are stale with any active worktree; list each with its worktree path so the user knows what to resolve manually
+
+Do NOT say "will be removed" for worktrees — removal is gated on confirmation in Step 4. If both the merged and stale candidate lists are empty, report "No branches to clean" and stop.
 
 **4. Confirm before deletion**
 
-Use AskUserQuestion with concrete options derived from the candidates found. Structure:
+Use AskUserQuestion. For merged branches that carry a worktree annotation, the confirmation option must name both the branch and its worktree path — the user is authorizing removal of both in one selection.
+
+Structure:
 - Header: "Branch cleanup"
-- For merged branches: ask "Delete these merged branches?" with options like "Delete all N merged branches" (label) / "Removes: branch-a, branch-b, ..." (description), and "Keep all merged branches"
-- For stale branches with multiple candidates: use multiSelect:true so the user can pick individual branches. Each option: label = branch name, description = age (e.g., "3 months ago")
+- For merged branches: one option per branch. If the branch has a worktree: label = "branch-name + worktree", description = "Removes branch and worktree at /path". If no worktree: label = branch name, description = "Removes local branch". Include a "Keep all merged branches" fallback. If there are multiple candidates with no worktrees, a "Delete all N" batch option is acceptable.
+- For stale branches: use multiSelect:true. Each option: label = branch name, description = age. (No stale branch with a worktree will appear here — they were moved to blocked in Step 2.)
 - Always include a "Skip — keep all" option
 
-Never proceed to deletion without explicit user confirmation through AskUserQuestion.
+The user selecting a branch-with-worktree option is explicit authorization to remove both. Never remove a worktree that was not explicitly included in a confirmed selection.
 
 **5. Execute deletion**
 
-Delete only what the user confirmed. For each branch:
+Delete only what the user confirmed. For each confirmed branch:
 
 1. If the branch has a `[worktree:/path]` annotation, remove the worktree first:
    ```bash
    git worktree remove /path/to/wt
    ```
-   If the worktree has uncommitted changes, `git worktree remove` will refuse — report the error and skip that branch rather than force-removing.
 
 2. Then delete the branch:
    ```bash
@@ -69,12 +85,6 @@ Delete only what the user confirmed. For each branch:
    git push origin --delete <branch-name>
    ```
    Remote deletion requires explicit user request — never delete remotes unless the user says so directly.
-
-## Safety Rules
-
-- Never delete: main, master, develop, release/*
-- Use `-d` not `-D` to preserve git's unmerged-commit safety check
-- Remote deletion only on explicit user request
 
 ## Output
 

--- a/plugins/claude-coding/skills/clean-branches/SKILL.md
+++ b/plugins/claude-coding/skills/clean-branches/SKILL.md
@@ -34,9 +34,9 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/clean-branches/scripts/find-candidates.sh "$PA
 ```
 The script outputs two labeled sections (`=== MERGED ===` and `=== STALE ===`), one branch per line. Branches checked out in a worktree are annotated: `branch-name [worktree:/path/to/wt]`. Parse each section into its own list, preserving the worktree annotation.
 
-After parsing, apply these worktree rules before building the candidate lists:
+After parsing, apply these worktree rules before building the candidate lists. Process the MERGED list first, then the STALE list — a branch that appears in both (merged AND older than 30 days) is governed by the MERGED rule only; skip it when processing STALE.
 
-- **Stale branch + active worktree** → move immediately to the **blocked** list, regardless of worktree state. A stale branch with a live worktree may still have in-progress work — never offer it for cleanup.
+- **Stale branch + active worktree** → move immediately to the **blocked** list, regardless of worktree state. A stale branch with a live worktree may still have in-progress work — never offer it for cleanup. Skip branches already classified as merged.
 - **Merged branch + active worktree** → check whether the worktree is clean:
   ```bash
   git -C /path/to/wt status --porcelain
@@ -73,6 +73,7 @@ Delete only what the user confirmed. For each confirmed branch:
    ```bash
    git worktree remove /path/to/wt
    ```
+   If the command fails (the worktree acquired changes in the window between Step 2 and now), report the error and skip that branch — do not force-remove.
 
 2. Then delete the branch:
    ```bash

--- a/plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh
+++ b/plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh
@@ -2,7 +2,7 @@
 # find-candidates.sh — Find merged and stale git branches
 # Usage: find-candidates.sh [pattern]
 # Output: Two labeled sections (MERGED / STALE), one branch per line.
-#         Merged branches checked out in a worktree are annotated: branch [worktree:/path]
+#         Branches checked out in a worktree are annotated: branch [worktree:/path]
 #         Empty section = no candidates of that type.
 # Exit 0 always; downstream decides what to do with empty output.
 


### PR DESCRIPTION
## Summary

- Stale branches with an active worktree are now **blocked unconditionally** — a live worktree signals in-progress work regardless of cleanliness, so they are never presented as cleanup candidates
- Merged branches with an active worktree now go through an upfront cleanliness check (`git status --porcelain`); dirty worktrees move to the blocked list before the user is ever asked
- Worktree removal is now **folded into the branch confirmation**: the AskUserQuestion option labels both the branch and worktree path together — one selection authorizes both, nothing is implicit
- Removed the "will be removed first" framing that implied automatic removal without confirmation
- Added a **Blocked** group to the Step 3 presentation so the user knows what to resolve manually
- Removed redundant Safety Rules section (rules already inline in Steps 2 and 5)
- Fixed `argument-hint` YAML quoting (lint auto-fix)

## Test plan

- [x] Run `/clean-branches` on a repo with a merged branch that has an active clean worktree — confirm the confirmation option names both branch and worktree path
- [x] Run on a repo with a merged branch that has a dirty worktree — confirm it appears in Blocked, not in candidates
- [x] Run on a repo with a stale branch that has an active worktree — confirm it appears in Blocked regardless of worktree state
- [x] Run on a repo with no worktree-annotated branches — confirm behaviour is unchanged