### PR TITLE
fix(claude-coding): always push with -u to set upstream tracking on new branches

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.36",
+      "version": "0.2.37",
       "source": "./plugins/claude-coding"
     },
     {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.36](https://img.shields.io/badge/v0.2.36-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.37](https://img.shields.io/badge/v0.2.37-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.36](https://img.shields.io/badge/v0.2.36-blue?style=flat-square)
+# claude-coding ![v0.2.37](https://img.shields.io/badge/v0.2.37-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/skills/push-pr/SKILL.md
+++ b/plugins/claude-coding/skills/push-pr/SKILL.md
@@ -143,7 +143,9 @@ Complete when: existing PR state is known and target status is determined.
 
 ### 6. Push
 
-Push the branch to origin. If no upstream is set, use `git push -u origin "$BRANCH"`.
+Always push with `git push -u origin "$BRANCH"` — the `-u` flag sets tracking on new branches
+and is a no-op when the upstream is already correctly set, so it is always safe to use.
+
 If push fails because the remote branch has diverged, run `git pull --rebase origin $BRANCH`
 and retry the push once. If the rebase itself has conflicts, stop and report.
 


### PR DESCRIPTION
## Summary
- Fixes a regression introduced in f72385e where Step 6 of the push-pr skill stopped reliably setting upstream tracking on newly-cut branches

## Root Cause
The repair-audit commit collapsed an explicit runtime bash check (`git rev-parse --abbrev-ref --symbolic-full-name @{u}`) into prose relying on pre-flight context. Pre-flight runs before step 2 cuts a new branch — so when the agent was on `main` (which tracks `origin/main`), the upstream count was non-zero. By step 6, the agent was on a new branch with no upstream, but the stale pre-flight data appeared to show an upstream was set, causing `git push` without `-u`.

## Fix
Replace the conditional with an unconditional `git push -u origin "$BRANCH"`. The `-u` flag is safe when the upstream is already correctly set — it just refreshes the tracking reference with no side effects.

## Changes
- `plugins/claude-coding/skills/push-pr/SKILL.md` — Step 6: always use `git push -u origin "$BRANCH"`

## Commits
- `afd44c7` fix(claude-coding): always push with -u to set upstream tracking on new branches