### PR TITLE
refactor: remove dead code across plugins and tests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.80",
+      "version": "0.8.81",
       "source": "./plugins/claude-memory"
     },
     {
@@ -44,7 +44,7 @@
     {
       "name": "claude-content",
       "description": "Content creation skills: image generation, video compression, conversion, GIF creation, social media formatting, and audio extraction",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "source": "./plugins/claude-content"
     },
     {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.80](https://img.shields.io/badge/v0.8.80-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.81](https://img.shields.io/badge/v0.8.81-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 
@@ -137,7 +137,7 @@ Structured thinking and multi-perspective deliberation tools for Claude Code.
 
 <a id="claude-content"></a>
 
-### 🎬 claude-content &nbsp; ![v0.4.4](https://img.shields.io/badge/v0.4.4-blue?style=flat-square)
+### 🎬 claude-content &nbsp; ![v0.4.5](https://img.shields.io/badge/v0.4.5-blue?style=flat-square)
 
 Content creation and processing tools for Claude Code. Image generation and the full video/audio manipulation workflow.
 

--- a/plugins/claude-content/.claude-plugin/plugin.json
+++ b/plugins/claude-content/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-content",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Content creation skills: image generation, video compression, conversion, GIF creation, social media formatting, and audio extraction",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-content/README.md
+++ b/plugins/claude-content/README.md
@@ -1,4 +1,4 @@
-# claude-content ![v0.4.4](https://img.shields.io/badge/v0.4.4-blue?style=flat-square)
+# claude-content ![v0.4.5](https://img.shields.io/badge/v0.4.5-blue?style=flat-square)
 
 Content creation and processing tools for Claude Code. Six skills covering image generation, video manipulation, social media formatting, and audio extraction.
 

--- a/plugins/claude-content/skills/generate-image/scripts/generate.py
+++ b/plugins/claude-content/skills/generate-image/scripts/generate.py
@@ -86,8 +86,6 @@ NB_RATIOS = PRO_RATIOS + ["1:4", "4:1", "1:8", "8:1"]
 PRO_RESOLUTIONS = ["1K", "2K", "4K"]
 NB_RESOLUTIONS = ["0.5K"] + PRO_RESOLUTIONS
 
-DEFAULT_OUTPUT_DIR = Path.home() / "Documents" / "generated images"
-
 
 # --- Aspect ratio auto-detection ---
 

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.80",
+  "version": "0.8.81",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.80](https://img.shields.io/badge/v0.8.80-blue?style=flat-square)
+# claude-memory ![v0.8.81](https://img.shields.io/badge/v0.8.81-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/hooks/onboarding.py
+++ b/plugins/claude-memory/hooks/onboarding.py
@@ -16,7 +16,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parent / "skills" / "recall-conversations" / "scripts"))
 
-from memory_lib.db import CONFIG_PATH, CURRENT_ONBOARDING_VERSION, load_config
+from memory_lib.db import CONFIG_PATH, CURRENT_ONBOARDING_VERSION, load_config  # noqa: F401 — CONFIG_PATH re-exported for test monkeypatching
 
 PYTHON_EXE = sys.executable
 WRITE_CONFIG_PATH = str(SCRIPT_DIR / "write_config.py")

--- a/plugins/claude-memory/skills/get-token-insights/scripts/ingest_token_data.py
+++ b/plugins/claude-memory/skills/get-token-insights/scripts/ingest_token_data.py
@@ -10,8 +10,6 @@ backfills token_snapshots, and outputs a JSON analysis blob to stdout.
 from __future__ import annotations
 
 import json
-import os
-import re
 import sqlite3
 import sys
 from dataclasses import dataclass, field
@@ -637,7 +635,7 @@ def compute_session_analytics(session: ParsedSession) -> dict:
     total_turn_ms = 0
     total_tool_errors = 0
 
-    cache_ttl_ms, cache_tier = _detect_cache_ttl_ms(session)
+    cache_ttl_ms, _ = _detect_cache_ttl_ms(session)
 
     for turn in session.turns:
         # Cache cliff detection
@@ -819,20 +817,6 @@ def backfill_token_snapshots(conn: sqlite3.Connection) -> None:
 
 
 # ── Helpers ───────────────────────────────────────────────────────────
-
-def _percentile(sorted_vals: list, p: float) -> float:
-    if not sorted_vals:
-        return 0.0
-    k = (len(sorted_vals) - 1) * p / 100.0
-    f = int(k)
-    c = f + 1
-    if c >= len(sorted_vals):
-        return float(sorted_vals[-1])
-    return sorted_vals[f] + (k - f) * (sorted_vals[c] - sorted_vals[f])
-
-
-def _avg(arr: list) -> float:
-    return sum(arr) / len(arr) if arr else 0.0
 
 
 def _project_slug(path: str | None) -> str:
@@ -1492,7 +1476,6 @@ def build_output(conn: sqlite3.Connection) -> dict:
         top_bash_cmds.append({"command": row[0], "count": row[1]})
 
     # Compute weighted average cost rates for waste-to-dollar conversion
-    total_all_input = total_input + total_cache_read + total_cache_creation
     avg_input_cpm = 5.0  # default to Opus 4.6 rate
     avg_output_cpm = 25.0
     if model_split:

--- a/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/db.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/db.py
@@ -594,7 +594,7 @@ def _migrate_project_paths(conn: sqlite3.Connection) -> None:
     cursor.execute("SELECT id, path, name FROM projects")
     projects = cursor.fetchall()
 
-    for proj_id, stored_path, stored_name in projects:
+    for proj_id, stored_path, _stored_name in projects:
         real_cwd = best_cwd.get(proj_id)
         if not real_cwd or real_cwd == stored_path:
             continue  # No cwd data or already correct
@@ -678,7 +678,7 @@ def setup_logging(settings: Optional[dict] = None) -> logging.Logger:
     Returns a null logger if logging is disabled.
     """
     logger = logging.getLogger("claude-memory")
-    logger.handlers = []  # Clear existing handlers
+    logger.handlers.clear()
 
     if not settings or not settings.get("logging_enabled", False):
         logger.addHandler(logging.NullHandler())

--- a/tests/claude-coding/test_pr_comments.py
+++ b/tests/claude-coding/test_pr_comments.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 
 from fetch_pr_comments import (
-    BOT_BODY_LIMIT,
     _deduplicate_actionable,
     _extract_section_key,
     _keys_match,
@@ -13,7 +12,6 @@ from fetch_pr_comments import (
     _parse_slurped,
     _short_date,
     _truncate,
-    build_result,
     classify_inline_comment,
     extract_sections,
     format_text,

--- a/tests/claude-memory/conftest.py
+++ b/tests/claude-memory/conftest.py
@@ -21,11 +21,6 @@ def memory_db():
     conn.close()
 
 
-@pytest.fixture
-def fixture_dir():
-    """Path to the fixtures directory."""
-    return FIXTURE_DIR
-
 
 @pytest.fixture(params=sorted(FIXTURE_DIR.glob("*.jsonl")), ids=lambda p: p.stem)
 def jsonl_fixture(request):

--- a/tests/claude-memory/test_clear_handoff_contract.py
+++ b/tests/claude-memory/test_clear_handoff_contract.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
-import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/claude-memory/test_context_injection.py
+++ b/tests/claude-memory/test_context_injection.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
-import json
 import sqlite3
 import sys
 from pathlib import Path
 from uuid import uuid4
 
-import pytest
 
 # Load memory-context.py as a module (hyphen in filename)
 HOOKS_DIR = Path(__file__).resolve().parents[2] / "plugins" / "claude-memory" / "hooks"

--- a/tests/claude-memory/test_db.py
+++ b/tests/claude-memory/test_db.py
@@ -7,7 +7,6 @@ import sqlite3
 import tempfile
 from pathlib import Path
 
-import pytest
 
 from memory_lib.db import (
     CURRENT_ONBOARDING_VERSION,

--- a/tests/claude-memory/test_import_pipeline.py
+++ b/tests/claude-memory/test_import_pipeline.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-import json
 import sqlite3
 import sys
 import tempfile
 from pathlib import Path
-from typing import Optional
 
 import pytest
 
 # Add hooks dir to sys.path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "plugins" / "claude-memory" / "hooks"))
 
-from import_conversations import import_session, import_project, get_file_hash
+from import_conversations import import_session, import_project
 from memory_lib.db import SCHEMA, _migrate_columns
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
@@ -203,7 +201,7 @@ class TestReimportIdempotent:
         fixture_file = FIXTURE_DIR / "linear_3_exchange.jsonl"
 
         # First import
-        branches1, messages1 = import_session(memory_db, fixture_file, project_id)
+        branches1, _messages1 = import_session(memory_db, fixture_file, project_id)
         assert branches1 > 0, "First import should succeed"
 
         # Count sessions after first import
@@ -290,7 +288,7 @@ class TestFKSafeReimport:
         fixture_file = FIXTURE_DIR / "linear_3_exchange.jsonl"
 
         # First import
-        branches1, messages1 = import_session(memory_db, fixture_file, project_id)
+        branches1, _messages1 = import_session(memory_db, fixture_file, project_id)
         assert branches1 > 0
         memory_db.commit()
 
@@ -311,7 +309,7 @@ class TestFKSafeReimport:
         memory_db.execute("PRAGMA foreign_keys = ON")
         fixture_file = FIXTURE_DIR / "single_rewind.jsonl"
 
-        branches1, messages1 = import_session(memory_db, fixture_file, project_id)
+        branches1, _messages1 = import_session(memory_db, fixture_file, project_id)
         assert branches1 == 3
         memory_db.commit()
 

--- a/tests/claude-memory/test_onboarding.py
+++ b/tests/claude-memory/test_onboarding.py
@@ -15,7 +15,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
 
 from memory_lib.db import CURRENT_ONBOARDING_VERSION
 

--- a/tests/claude-memory/test_parsing.py
+++ b/tests/claude-memory/test_parsing.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import uuid as uuid_mod
 from pathlib import Path
 

--- a/tests/claude-memory/test_search.py
+++ b/tests/claude-memory/test_search.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sqlite3
 import sys
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 

--- a/tests/claude-memory/test_write_config.py
+++ b/tests/claude-memory/test_write_config.py
@@ -147,15 +147,13 @@ class TestWriteConfigNonDictExistingConfig:
 
 
 class TestWriteConfigAtomicWrite:
-    def test_no_tmp_file_left_on_write_failure(self, tmp_path, monkeypatch, capsys):
+    def test_no_tmp_file_left_on_write_failure(self, tmp_path, monkeypatch):
         """If the atomic write fails, no .tmp file should remain — prevents stale temp artifacts."""
         import os
         cfg = tmp_path / "config.json"
         _patch_config_path(monkeypatch, cfg)
 
         # Patch os.fdopen to raise after the tempfile is created
-        real_fdopen = os.fdopen
-
         def exploding_fdopen(fd, mode):
             # Close the fd to avoid leaking it, then raise
             os.close(fd)
@@ -176,8 +174,6 @@ class TestWriteConfigAtomicWrite:
         cfg = tmp_path / "config.json"
         cfg.write_text(json.dumps(original))
         _patch_config_path(monkeypatch, cfg)
-
-        real_fdopen = os.fdopen
 
         def exploding_fdopen(fd, mode):
             os.close(fd)


### PR DESCRIPTION
## Summary
- Remove unused imports (`json`, `time`, `pytest`, `re`, `os`, `uuid4`, `Optional`)
- Remove unused variables (`cache_tier` → `_`, `stored_name` → `_stored_name`, `messages1` → `_messages1`)
- Remove unused functions (`_percentile`, `_avg`) and constants (`DEFAULT_OUTPUT_DIR`)
- Remove unused fixtures (`fixture_dir`) and dead locals (`real_fdopen`, `total_all_input`)
- Add `noqa: F401` annotation for `CONFIG_PATH` re-export used by test monkeypatching
- Replace `logger.handlers = []` with idiomatic `logger.handlers.clear()`

## Test plan
- [ ] Existing test suite passes (no behavioral changes)
- [ ] Ruff lint clean on changed files