### PR TITLE
refactor: agent config cleanup and token import test coverage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.40",
+      "version": "0.2.41",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.39",
+      "version": "0.2.40",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.38",
+      "version": "0.2.39",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "name": "claude-skills",
       "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
-      "version": "0.5.22",
+      "version": "0.5.23",
       "source": "./plugins/claude-skills"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,7 +38,7 @@
     {
       "name": "claude-thinking",
       "description": "Structured thinking and multi-perspective deliberation tools",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "source": "./plugins/claude-thinking"
     },
     {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.40](https://img.shields.io/badge/v0.2.40-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.41](https://img.shields.io/badge/v0.2.41-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ A `skill-lint` agent runs automatically after `create-skill` and `improve-skill`
 
 <a id="claude-thinking"></a>
 
-### 🧠 claude-thinking &nbsp; ![v0.3.3](https://img.shields.io/badge/v0.3.3-blue?style=flat-square)
+### 🧠 claude-thinking &nbsp; ![v0.3.4](https://img.shields.io/badge/v0.3.4-blue?style=flat-square)
 
 Structured thinking and multi-perspective deliberation tools for Claude Code.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Coding workflow skills for Claude Code. Nine skills and two agents covering the 
 
 <a id="claude-skills"></a>
 
-### ✍️ claude-skills &nbsp; ![v0.5.22](https://img.shields.io/badge/v0.5.22-blue?style=flat-square)
+### ✍️ claude-skills &nbsp; ![v0.5.23](https://img.shields.io/badge/v0.5.23-blue?style=flat-square)
 
 Skill authoring tools for Claude Code. Six skills covering the full lifecycle from creation to repair.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.38](https://img.shields.io/badge/v0.2.38-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.39](https://img.shields.io/badge/v0.2.39-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.39](https://img.shields.io/badge/v0.2.39-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.40](https://img.shields.io/badge/v0.2.40-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.38](https://img.shields.io/badge/v0.2.38-blue?style=flat-square)
+# claude-coding ![v0.2.39](https://img.shields.io/badge/v0.2.39-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.39](https://img.shields.io/badge/v0.2.39-blue?style=flat-square)
+# claude-coding ![v0.2.40](https://img.shields.io/badge/v0.2.40-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.40](https://img.shields.io/badge/v0.2.40-blue?style=flat-square)
+# claude-coding ![v0.2.41](https://img.shields.io/badge/v0.2.41-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/agents/architecture-auditor.md
+++ b/plugins/claude-coding/agents/architecture-auditor.md
@@ -13,17 +13,12 @@ tools:
   - Grep
   - Glob
   - Bash
-  - Agent
 maxTurns: 20
 ---
 
-You are a software architecture specialist who operates in two modes depending on context: as a
-quick advisor during implementation decisions, and as a thorough auditor when reviewing existing
-or newly-written code.
+You are a software architecture specialist who operates in two modes depending on context: as a quick advisor during implementation decisions, and as a thorough auditor when reviewing existing or newly-written code.
 
-Update your agent memory as you discover architectural patterns, module boundaries, dependency
-structures, and design decisions in this project. Consult your memory before starting work —
-prior runs may have already mapped the codebase structure.
+Update your agent memory as you discover architectural patterns, module boundaries, dependency structures, and design decisions in this project. Consult your memory before starting work — prior runs may have already mapped the codebase structure.
 
 **Mode selection rules:**
 - Forward-looking questions ("should I...", "which pattern...", "how should I structure...") → Advisor
@@ -34,11 +29,6 @@ prior runs may have already mapped the codebase structure.
 You use Bash exclusively for read-only structural commands: `tree`, `find -type f`, `wc -l`.
 Prefer the Read tool for reading file contents. You never run mutating commands (`rm`, `mv`,
 `git commit`, `git reset`, `>` redirection, build/test/package commands).
-
-**Explore subagents:** For projects with 50+ files, you may spawn up to 3 Explore subagents
-(via the Agent tool with `subagent_type: Explore`) to parallelize structure mapping and
-dependency tracing across different module clusters. For smaller projects, use Read/Grep/Glob
-directly — subagent overhead is not worth it.
 
 ## Advisor Mode
 

--- a/plugins/claude-coding/agents/code-auditor.md
+++ b/plugins/claude-coding/agents/code-auditor.md
@@ -14,7 +14,6 @@ tools:
   - Grep
   - Glob
   - Bash
-  - Agent
 maxTurns: 20
 ---
 
@@ -42,13 +41,6 @@ You use Bash exclusively for read-only structural commands: `git diff`, `git log
 `find -type f`, `wc -l`. Prefer the Read tool for reading file contents. You never run
 mutating commands (`rm`, `mv`, `git commit`, `git reset`, `>` redirection, build/test/package
 commands).
-
-**Explore subagents:** You may spawn Explore subagents (via the Agent tool with
-`subagent_type: Explore`) to parallelize exploration-heavy steps:
-- Step 2 (correctness): one subagent per file group when changes span 5+ files
-- Step 4 (dead code): one subagent per module cluster to trace import/export graphs in parallel
-- Step 5 (consistency): one subagent to scan existing files for dominant conventions while you
-  review the changed code
 
 ## Advisor Mode
 

--- a/plugins/claude-coding/skills/clean-branches/SKILL.md
+++ b/plugins/claude-coding/skills/clean-branches/SKILL.md
@@ -2,12 +2,11 @@
 name: clean-branches
 description: >
   This skill should be used when the user says "clean up branches", "delete merged
-  branches", "prune stale branches", "git branch cleanup", "remove old branches",
-  or wants to tidy up or purge old branches.
+  branches", or "prune stale branches". Use whenever the user mentions branch cleanup,
+  pruning, or stale branch deletion — even if they don't say "clean-branches" explicitly.
 argument-hint: "[branch-pattern]"
 allowed-tools:
-  - Bash(git:*)
-  - Bash(bash:*)
+  - Bash
   - AskUserQuestion
 ---
 
@@ -17,8 +16,7 @@ Safely remove merged and stale git branches with confirmation.
 
 ## Process
 
-**0. Parse arguments**
-If `$ARGUMENTS` provided, treat it as a glob pattern to filter branch candidates (e.g., `feature/*` shows only feature branches). Pass it to the candidate script in Step 2.
+If `$ARGUMENTS` is provided, treat it as a glob pattern to filter branch candidates (e.g., `feature/*`) and pass it to the candidate script in Step 1.
 
 **1. Fetch latest state**
 ```bash
@@ -32,7 +30,11 @@ Run the candidate detection script, passing the optional pattern filter:
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/skills/clean-branches/scripts/find-candidates.sh "$PATTERN"
 ```
-The script outputs two labeled sections (`=== MERGED ===` and `=== STALE ===`), one branch per line. Branches checked out in a worktree are annotated: `branch-name [worktree:/path/to/wt]`. Parse each section into its own list, preserving the worktree annotation.
+The script outputs two labeled sections (`=== MERGED ===` and `=== STALE ===`), one branch per line. Branches carry two optional annotations:
+- `[worktree:/path/to/wt]` — branch is checked out in a worktree
+- `[squash-merged]` — branch was merged via squash or rebase PR; git does not recognize it as merged locally (requires force-delete in Step 5)
+
+Parse each section into its own list, preserving both annotations.
 
 After parsing, apply these worktree rules before building the candidate lists. Process the MERGED list first, then the STALE list — a branch that appears in both (merged AND older than 30 days) is governed by the MERGED rule only; skip it when processing STALE.
 
@@ -59,7 +61,7 @@ Use AskUserQuestion. For merged branches that carry a worktree annotation, the c
 
 Structure:
 - Header: "Branch cleanup"
-- For merged branches: one option per branch. If the branch has a worktree: label = "branch-name + worktree", description = "Removes branch and worktree at /path". If no worktree: label = branch name, description = "Removes local branch". Include a "Keep all merged branches" fallback. If there are multiple candidates with no worktrees, a "Delete all N" batch option is acceptable.
+- For merged branches: one option per branch. If the branch has a worktree: label = "branch-name + worktree", description = "Removes branch and worktree at /path". If the branch is squash/rebase-merged: append "(squash/rebase PR — force delete)" to the description so the user knows `-D` will be used. If no worktree and not squash-merged: label = branch name, description = "Removes local branch". Include a "Keep all merged branches" fallback. If there are multiple candidates with no worktrees, a "Delete all N" batch option is acceptable.
 - For stale branches: use multiSelect:true. Each option: label = branch name, description = age. (No stale branch with a worktree will appear here — they were moved to blocked in Step 2.)
 - Always include a "Skip — keep all" option
 
@@ -76,16 +78,19 @@ Delete only what the user confirmed. For each confirmed branch:
    If the command fails (the worktree acquired changes in the window between Step 2 and now), report the error and skip that branch — do not force-remove.
 
 2. Then delete the branch:
-   ```bash
-   git branch -d <branch-name>
-   ```
-   Use `-d` (not `-D`) — git refuses to delete branches with unmerged commits.
+   - Regular merged (no `[squash-merged]` annotation): `git branch -d <branch-name>`
+   - Squash/rebase-merged (`[squash-merged]` annotation): `git branch -D <branch-name>`
 
-3. If the user explicitly requests remote cleanup:
+   `-D` is required for squash/rebase-merged branches because git does not recognise their commits as merged into base — using `-d` will fail. The `[squash-merged]` annotation on a confirmed selection is explicit user authorisation to force-delete.
+
+3. After local deletions are complete, offer remote cleanup:
+
+   Use AskUserQuestion with multiSelect:true listing every branch that was successfully deleted locally and has a known remote (`git ls-remote --heads origin <branch-name>` to verify). Let the user select which remotes to also delete. If none have a remote, skip this step.
+
+   For each selected remote:
    ```bash
    git push origin --delete <branch-name>
    ```
-   Remote deletion requires explicit user request — never delete remotes unless the user says so directly.
 
 ## Output
 

--- a/plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh
+++ b/plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh
@@ -64,6 +64,37 @@ while IFS= read -r branch; do
   fi
 done <<< "$MERGED"
 
+# --- Squash/rebase-merged detection via GitHub PR history ---
+# git branch --merged only detects true merge commits; squash and rebase merges
+# rewrite commits so the branch ancestry never appears in main. gh pr list is the
+# only reliable source for these.
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  GH_MERGED=$(gh pr list --state merged --limit 300 --json headRefName --jq '.[].headRefName' 2>/dev/null || true)
+  if [ -n "$GH_MERGED" ]; then
+    while IFS= read -r branch; do
+      [ -z "$branch" ] && continue
+      # Skip protected branches
+      case "$branch" in main|master|develop|release/*) continue ;; esac
+      # Skip branches already caught by git branch --merged
+      echo "$MERGED" | grep -qx "$branch" && continue
+      # Apply pattern filter
+      if [ -n "$PATTERN" ] && ! echo "$branch" | grep -q "$PATTERN"; then
+        continue
+      fi
+      # Confirm branch exists locally
+      git rev-parse --verify "$branch" >/dev/null 2>&1 || continue
+      # Check if a merged PR targeted this branch
+      echo "$GH_MERGED" | grep -qx "$branch" || continue
+      wt=$(worktree_for "$branch")
+      if [[ -n "$wt" ]]; then
+        echo "$branch [worktree:$wt] [squash-merged]"
+      else
+        echo "$branch [squash-merged]"
+      fi
+    done < <(git branch --format='%(refname:short)')
+  fi
+fi
+
 # --- Stale branches (no commits in 30+ days) ---
 # Unix timestamps used for accurate threshold — git relative dates miss edge cases
 echo "=== STALE ==="

--- a/plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh
+++ b/plugins/claude-coding/skills/clean-branches/scripts/find-candidates.sh
@@ -76,7 +76,7 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
       # Skip protected branches
       case "$branch" in main|master|develop|release/*) continue ;; esac
       # Skip branches already caught by git branch --merged
-      echo "$MERGED" | grep -qx "$branch" && continue
+      echo "$MERGED" | grep -qFx "$branch" && continue
       # Apply pattern filter
       if [ -n "$PATTERN" ] && ! echo "$branch" | grep -q "$PATTERN"; then
         continue
@@ -84,7 +84,7 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
       # Confirm branch exists locally
       git rev-parse --verify "$branch" >/dev/null 2>&1 || continue
       # Check if a merged PR targeted this branch
-      echo "$GH_MERGED" | grep -qx "$branch" || continue
+      echo "$GH_MERGED" | grep -qFx "$branch" || continue
       wt=$(worktree_for "$branch")
       if [[ -n "$wt" ]]; then
         echo "$branch [worktree:$wt] [squash-merged]"

--- a/plugins/claude-skills/.claude-plugin/plugin.json
+++ b/plugins/claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-skills/README.md
+++ b/plugins/claude-skills/README.md
@@ -1,4 +1,4 @@
-# claude-skills ![v0.5.22](https://img.shields.io/badge/v0.5.22-blue?style=flat-square)
+# claude-skills ![v0.5.23](https://img.shields.io/badge/v0.5.23-blue?style=flat-square)
 
 Skill and agent authoring tools for Claude Code. Six complementary skills: one generates skills from scratch, one generates agents, one audits skills for structural correctness, one audits agents for structural correctness, one improves skills for effectiveness, and one designs CLI interfaces for the scripts those skills produce. A bundled `skill-lint` agent runs structural linting automatically after skill creation or improvement.
 

--- a/plugins/claude-skills/agents/skill-lint.md
+++ b/plugins/claude-skills/agents/skill-lint.md
@@ -7,6 +7,7 @@ description: >
   Not for agent files — those have a different contract.
 model: inherit
 color: yellow
+memory: project
 tools:
   - Read
   - Glob
@@ -98,3 +99,12 @@ VALIDATION: [N/N] checklist items pass
 - Skill path is a single file (not in a directory): audit the file; skip anatomy dimension
 - Skill is an agent file (AGENT.md): decline — agent linting is a different contract
 - No findings at any severity: report "Clean — no structural issues found"
+
+## Agent Memory
+
+Update your agent memory as you discover recurring skill patterns, common violations per
+project, and conventions that differ across codebases. Consult your memory before starting
+work — prior runs may have already identified this project's dominant skill conventions.
+
+After each run, append to your agent MEMORY.md: skill linted, finding counts by severity
+(critical/major/minor: N each), and any project-specific calibration notes for future runs.

--- a/plugins/claude-thinking/.claude-plugin/plugin.json
+++ b/plugins/claude-thinking/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-thinking",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Structured thinking and multi-perspective deliberation tools",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-thinking/README.md
+++ b/plugins/claude-thinking/README.md
@@ -1,4 +1,4 @@
-# claude-thinking ![v0.3.3](https://img.shields.io/badge/v0.3.3-blue?style=flat-square)
+# claude-thinking ![v0.3.4](https://img.shields.io/badge/v0.3.4-blue?style=flat-square)
 
 Structured thinking and multi-perspective deliberation tools for Claude Code. Single-agent dialogue for clarifying ideas, and multi-agent councils for stress-testing decisions from multiple cognitive frames.
 

--- a/plugins/claude-thinking/skills/brainstorm/SKILL.md
+++ b/plugins/claude-thinking/skills/brainstorm/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: brainstorm
-description: >
-  This skill should be used when the user says "interview me about", "help me clarify",
-  "stress-test my idea", "let's explore this concept", "challenge my assumptions about",
-  "probe my assumptions", or needs structured questioning to refine and articulate
-  their thinking.
-model: opus
-allowed-tools: [Read, Write, AskUserQuestion]
+description: |
+  This skill should be used when the user says "interview me about", "help me clarify", "stress-test my idea", "let's explore this concept", "challenge my assumptions about", "probe my assumptions", or needs structured questioning to refine and articulate their thinking.
+allowed-tools:
+  - Read
+  - Write
+  - AskUserQuestion
 argument-hint: "[topic] - optional topic to interview about"
 ---
 

--- a/tests/claude-memory/test_ingest_token_data.py
+++ b/tests/claude-memory/test_ingest_token_data.py
@@ -205,3 +205,326 @@ class TestSessionMetricsStableOnReimport:
             f"Expected exactly 1 session_metrics row, got {count} — "
             "INSERT OR REPLACE must upsert, not insert a second row"
         )
+
+
+# ---------------------------------------------------------------------------
+# token_import_log schema
+# ---------------------------------------------------------------------------
+
+class TestTokenImportLogSchema:
+    """token_import_log must exist with the correct columns after ensure_schema."""
+
+    def test_table_exists(self, token_db):
+        """token_import_log must be present after schema initialisation."""
+        row = token_db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='token_import_log'"
+        ).fetchone()
+        assert row is not None, "token_import_log table is missing after ensure_schema"
+
+    def test_required_columns_present(self, token_db):
+        """token_import_log must have file_path, mtime_ns, imported_at, session_id, turn_count."""
+        cursor = token_db.execute("PRAGMA table_info(token_import_log)")
+        columns = {row[1] for row in cursor.fetchall()}
+        required = {"file_path", "mtime_ns", "imported_at", "session_id", "turn_count"}
+        missing = required - columns
+        assert not missing, f"token_import_log is missing columns: {missing}"
+
+    def test_file_path_unique_constraint(self, token_db, tmp_path):
+        """file_path must be UNIQUE — second insert for the same path must use INSERT OR REPLACE."""
+        f = tmp_path / "dup.jsonl"
+        f.write_text("")
+        token_db.execute(
+            "INSERT INTO token_import_log (file_path, mtime_ns) VALUES (?, ?)",
+            (str(f), 1000),
+        )
+        token_db.commit()
+        # A plain INSERT should violate the unique constraint
+        with pytest.raises(sqlite3.IntegrityError):
+            token_db.execute(
+                "INSERT INTO token_import_log (file_path, mtime_ns) VALUES (?, ?)",
+                (str(f), 2000),
+            )
+            token_db.commit()
+
+    def test_import_log_not_present(self, token_db):
+        """The legacy import_log table must NOT exist — ensure_schema drops it on v4 init."""
+        row = token_db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='import_log'"
+        ).fetchone()
+        assert row is None, (
+            "Legacy import_log table must not exist in a v4 schema — "
+            "token_import_log is the authoritative source for ingest state"
+        )
+
+
+# ---------------------------------------------------------------------------
+# should_skip_file
+# ---------------------------------------------------------------------------
+
+class TestShouldSkipFile:
+    """should_skip_file must gate re-ingestion correctly based on mtime."""
+
+    def test_new_file_not_skipped(self, token_db, tmp_path):
+        """A file with no entry in token_import_log must return False."""
+        # Prevents: new JSONL files silently ignored after a fresh schema install
+        from ingest_token_data import should_skip_file
+        f = tmp_path / "new-session.jsonl"
+        f.write_text("")
+        assert should_skip_file(token_db, f) is False
+
+    def test_already_imported_same_mtime_skipped(self, token_db, tmp_path):
+        """A file already recorded with its current mtime must return True."""
+        # Prevents: files being re-parsed on every run, inflating cost metrics
+        from ingest_token_data import record_import, should_skip_file
+        f = tmp_path / "imported-session.jsonl"
+        f.write_text("")
+        record_import(token_db, f, "sess-skip", turn_count=3)
+        token_db.commit()
+        assert should_skip_file(token_db, f) is True
+
+    def test_updated_mtime_not_skipped(self, token_db, tmp_path):
+        """A file recorded with an older mtime must return False so it is re-ingested."""
+        # Prevents: appended JSONL files (new turns) being silently skipped
+        from ingest_token_data import should_skip_file
+        f = tmp_path / "updated-session.jsonl"
+        f.write_text("")
+        stale_mtime = f.stat().st_mtime_ns - 1_000_000  # 1 ms in the past
+        token_db.execute(
+            "INSERT INTO token_import_log (file_path, mtime_ns) VALUES (?, ?)",
+            (str(f), stale_mtime),
+        )
+        token_db.commit()
+        assert should_skip_file(token_db, f) is False
+
+    def test_missing_file_skipped(self, token_db, tmp_path):
+        """A file that no longer exists on disk must return True (cannot be read)."""
+        from ingest_token_data import should_skip_file
+        ghost = tmp_path / "gone.jsonl"
+        # ghost does not exist; should_skip_file catches OSError and returns True
+        assert should_skip_file(token_db, ghost) is True
+
+
+# ---------------------------------------------------------------------------
+# record_import
+# ---------------------------------------------------------------------------
+
+class TestRecordImport:
+    """record_import must write and overwrite token_import_log rows correctly."""
+
+    def test_inserts_new_row(self, token_db, tmp_path):
+        """First call must create a row in token_import_log with correct values."""
+        # Prevents: import state not being persisted, causing every run to re-ingest everything
+        from ingest_token_data import record_import
+        f = tmp_path / "record-new.jsonl"
+        f.write_text("")
+        record_import(token_db, f, "sess-new", turn_count=5)
+        token_db.commit()
+
+        row = token_db.execute(
+            "SELECT session_id, turn_count, mtime_ns FROM token_import_log WHERE file_path = ?",
+            (str(f),),
+        ).fetchone()
+        assert row is not None, "record_import must create a row in token_import_log"
+        session_id, turn_count, mtime_ns = row
+        assert session_id == "sess-new"
+        assert turn_count == 5
+        assert mtime_ns == f.stat().st_mtime_ns
+
+    def test_updates_existing_row(self, token_db, tmp_path):
+        """Second call for the same file must overwrite the existing row, not insert a duplicate."""
+        # Prevents: unique constraint violations crashing the ingest loop on re-runs
+        from ingest_token_data import record_import
+        f = tmp_path / "record-update.jsonl"
+        f.write_text("")
+        record_import(token_db, f, "sess-v1", turn_count=2)
+        token_db.commit()
+
+        # Simulate more turns being added (mtime changes after a write)
+        f.write_text("updated")
+        record_import(token_db, f, "sess-v1", turn_count=7)
+        token_db.commit()
+
+        rows = token_db.execute(
+            "SELECT turn_count, mtime_ns FROM token_import_log WHERE file_path = ?",
+            (str(f),),
+        ).fetchall()
+        assert len(rows) == 1, f"Expected 1 row after upsert, got {len(rows)}"
+        assert rows[0][0] == 7, "turn_count must be updated to latest value"
+        assert rows[0][1] == f.stat().st_mtime_ns, "mtime_ns must reflect current file state"
+
+    def test_imported_at_is_set(self, token_db, tmp_path):
+        """imported_at must be a non-null datetime string after record_import."""
+        from ingest_token_data import record_import
+        f = tmp_path / "record-ts.jsonl"
+        f.write_text("")
+        record_import(token_db, f, "sess-ts", turn_count=1)
+        token_db.commit()
+
+        imported_at = token_db.execute(
+            "SELECT imported_at FROM token_import_log WHERE file_path = ?",
+            (str(f),),
+        ).fetchone()[0]
+        assert imported_at is not None, "imported_at must be set by record_import"
+
+
+# ---------------------------------------------------------------------------
+# Table isolation — token_import_log vs import_log
+# ---------------------------------------------------------------------------
+
+class TestTableIsolation:
+    """token_import_log rows must never affect import_log and vice-versa."""
+
+    def test_token_import_log_writes_do_not_create_import_log(self, token_db, tmp_path):
+        """Writing to token_import_log must not cause import_log to appear."""
+        from ingest_token_data import record_import
+        f = tmp_path / "isolation-check.jsonl"
+        f.write_text("")
+        record_import(token_db, f, "sess-iso", turn_count=1)
+        token_db.commit()
+
+        row = token_db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='import_log'"
+        ).fetchone()
+        assert row is None, (
+            "import_log must not be created as a side-effect of token_import_log writes"
+        )
+
+    def test_schema_version_table_present(self, token_db):
+        """schema_version table must exist — used to gate v4 migration logic."""
+        row = token_db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'"
+        ).fetchone()
+        assert row is not None, "schema_version table must exist after ensure_schema"
+
+    def test_schema_version_is_4(self, token_db):
+        """schema_version must be SCHEMA_VERSION (4) after a fresh ensure_schema."""
+        from ingest_token_data import SCHEMA_VERSION
+        version = token_db.execute(
+            "SELECT version FROM schema_version"
+        ).fetchone()[0]
+        assert version == SCHEMA_VERSION, (
+            f"Expected schema version {SCHEMA_VERSION}, got {version}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# v3 → v4 migration
+# ---------------------------------------------------------------------------
+
+def _v3_token_db() -> sqlite3.Connection:
+    """Build an in-memory DB that mimics a pre-v4 token ingest schema.
+
+    We let ensure_schema create all the standard tables via SCHEMA_SQL, then
+    retroactively patch the DB to look like a v3 state:
+    - Recreate the legacy import_log table that existed before v4
+    - Set schema_version to 3 so ensure_schema triggers the upgrade path
+    - Optionally seed stale token_import_log rows to verify they are cleared
+
+    We do NOT pre-stub turns/session_metrics — ensure_schema must create them
+    at their full column width to avoid OperationalError on ALTER TABLE calls.
+    """
+    from ingest_token_data import SCHEMA_SQL
+    conn = sqlite3.connect(":memory:")
+    # Apply the full schema so all tables exist with correct columns
+    conn.executescript(SCHEMA_SQL)
+    conn.commit()
+
+    # Legacy table that must be dropped by v4 migration
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS import_log (
+            id INTEGER PRIMARY KEY,
+            file_path TEXT UNIQUE NOT NULL,
+            file_hash TEXT,
+            imported_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            messages_imported INTEGER DEFAULT 0
+        )
+    """)
+    # Set schema_version to 3 to trigger the v4 upgrade path
+    conn.execute("CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)")
+    conn.execute("DELETE FROM schema_version")
+    conn.execute("INSERT INTO schema_version (version) VALUES (3)")
+    conn.commit()
+    return conn
+
+
+class TestV3ToV4Migration:
+    """ensure_schema on a v3 DB must upgrade cleanly to v4."""
+
+    def test_migration_bumps_schema_version(self):
+        """After ensure_schema on a v3 DB, schema_version must be 4."""
+        from ingest_token_data import SCHEMA_VERSION, ensure_schema
+        conn = _v3_token_db()
+        ensure_schema(conn)
+        version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
+        assert version == SCHEMA_VERSION
+        conn.close()
+
+    def test_migration_drops_legacy_import_log(self):
+        """ensure_schema on a v3 DB must DROP the legacy import_log table."""
+        # Prevents: legacy import_log rows for conversation files interfering with
+        # the token ingest skip-file logic after a schema upgrade.
+        from ingest_token_data import ensure_schema
+        conn = _v3_token_db()
+        # Confirm import_log exists before migration
+        assert conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='import_log'"
+        ).fetchone() is not None
+
+        ensure_schema(conn)
+
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='import_log'"
+        ).fetchone()
+        assert row is None, (
+            "import_log must be dropped during v3→v4 migration — "
+            "token_import_log is the sole ingest-state table post-v4"
+        )
+        conn.close()
+
+    def test_migration_clears_stale_token_import_log(self):
+        """ensure_schema on a v3 DB must DELETE all stale token_import_log rows."""
+        # Prevents: old mtime fingerprints from a different schema causing files
+        # to be permanently skipped after a schema upgrade forces full re-import.
+        from ingest_token_data import ensure_schema
+        conn = _v3_token_db()
+        conn.execute(
+            "INSERT INTO token_import_log (file_path, mtime_ns) VALUES ('/old/file.jsonl', 999)"
+        )
+        conn.commit()
+
+        ensure_schema(conn)
+
+        count = conn.execute("SELECT COUNT(*) FROM token_import_log").fetchone()[0]
+        assert count == 0, (
+            f"token_import_log must be cleared on schema upgrade, found {count} rows"
+        )
+        conn.close()
+
+    def test_migration_token_import_log_functional_after_upgrade(self, tmp_path):
+        """After v3→v4 migration, record_import and should_skip_file must work correctly."""
+        from ingest_token_data import ensure_schema, record_import, should_skip_file
+        conn = _v3_token_db()
+        ensure_schema(conn)
+
+        f = tmp_path / "post-migration.jsonl"
+        f.write_text("")
+
+        # File is new — must not be skipped
+        assert should_skip_file(conn, f) is False
+
+        record_import(conn, f, "sess-post-migration", turn_count=4)
+        conn.commit()
+
+        # Same mtime — must be skipped now
+        assert should_skip_file(conn, f) is True
+        conn.close()
+
+    def test_migration_idempotent(self):
+        """Calling ensure_schema twice on an already-v4 DB must be a safe no-op."""
+        from ingest_token_data import SCHEMA_VERSION, ensure_schema
+        conn = _v3_token_db()
+        ensure_schema(conn)   # v3 → v4
+        ensure_schema(conn)   # already v4, no-op
+        version = conn.execute("SELECT version FROM schema_version").fetchone()[0]
+        assert version == SCHEMA_VERSION
+        conn.close()

--- a/tests/claude-memory/test_ingest_token_data.py
+++ b/tests/claude-memory/test_ingest_token_data.py
@@ -244,7 +244,6 @@ class TestTokenImportLogSchema:
                 "INSERT INTO token_import_log (file_path, mtime_ns) VALUES (?, ?)",
                 (str(f), 2000),
             )
-            token_db.commit()
 
     def test_import_log_not_present(self, token_db):
         """The legacy import_log table must NOT exist — ensure_schema drops it on v4 init."""


### PR DESCRIPTION
## Summary
- Remove `Agent` tool and Explore subagent delegation guidance from architecture-auditor and code-auditor (reduces tool surface and removes guidance that encouraged unnecessary subagent spawning)
- Add project memory capability to skill-lint agent so it learns project-specific conventions across runs
- Fix brainstorm SKILL.md YAML formatting (block sequence tools, `|` description style) and drop explicit `model: opus` override
- Add `token_import_log` schema tests and `should_skip_file` coverage for the token ingest pipeline

## Changes
- `plugins/claude-coding/agents/architecture-auditor.md`
- `plugins/claude-coding/agents/code-auditor.md`
- `plugins/claude-skills/agents/skill-lint.md`
- `plugins/claude-thinking/skills/brainstorm/SKILL.md`
- `tests/claude-memory/test_ingest_token_data.py`

## Commits
- `eebd23d` refactor(coding): remove Agent tool and Explore subagent guidance from auditors
- `9db3edd` feat(skills): add project memory to skill-lint agent
- `dc5fd13` refactor(thinking): fix brainstorm SKILL.md yaml formatting and drop model override
- `905cff8` test(memory): add token_import_log schema and should_skip_file coverage

## Test plan
- [ ] Verify architecture-auditor and code-auditor no longer list `Agent` in their tools
- [ ] Verify skill-lint agent has `memory: project` and Agent Memory section
- [ ] Verify brainstorm SKILL.md parses cleanly (no `model` key, block-sequence tools)
- [ ] Run `pytest tests/claude-memory/test_ingest_token_data.py` — all new classes pass