### PR TITLE
docs: escape bang-backtick patterns and fix stray fence in skill docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "name": "claude-skills",
       "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
-      "version": "0.5.23",
+      "version": "0.5.24",
       "source": "./plugins/claude-skills"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "name": "claude-skills",
       "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
-      "version": "0.5.24",
+      "version": "0.5.25",
       "source": "./plugins/claude-skills"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.94",
+      "version": "0.8.95",
       "source": "./plugins/claude-memory"
     },
     {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.94](https://img.shields.io/badge/v0.8.94-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.95](https://img.shields.io/badge/v0.8.95-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Coding workflow skills for Claude Code. Nine skills and two agents covering the 
 
 <a id="claude-skills"></a>
 
-### ✍️ claude-skills &nbsp; ![v0.5.23](https://img.shields.io/badge/v0.5.23-blue?style=flat-square)
+### ✍️ claude-skills &nbsp; ![v0.5.24](https://img.shields.io/badge/v0.5.24-blue?style=flat-square)
 
 Skill authoring tools for Claude Code. Six skills covering the full lifecycle from creation to repair.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Coding workflow skills for Claude Code. Nine skills and two agents covering the 
 
 <a id="claude-skills"></a>
 
-### ✍️ claude-skills &nbsp; ![v0.5.24](https://img.shields.io/badge/v0.5.24-blue?style=flat-square)
+### ✍️ claude-skills &nbsp; ![v0.5.25](https://img.shields.io/badge/v0.5.25-blue?style=flat-square)
 
 Skill authoring tools for Claude Code. Six skills covering the full lifecycle from creation to repair.
 

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.94",
+  "version": "0.8.95",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.94](https://img.shields.io/badge/v0.8.94-blue?style=flat-square)
+# claude-memory ![v0.8.95](https://img.shields.io/badge/v0.8.95-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/skills/extract-learnings/SKILL.md
+++ b/plugins/claude-memory/skills/extract-learnings/SKILL.md
@@ -93,7 +93,6 @@ Phase 2 is complete when both agents return reports. If either returns empty or 
    - <old line>
    + <new line>
    ```
-   ```
 7. MEMORY.md line check — if over 170 lines, propose specific demotions to L3 or removals
 8. Layer 0 gate — if targeting `~/.claude/CLAUDE.md`, warn: "This modifies global instructions loaded in every session across all projects. Confirm?"
 9. AskUserQuestion: Approve all / Approve selectively / Reject

--- a/plugins/claude-skills/.claude-plugin/plugin.json
+++ b/plugins/claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "0.5.23",
+  "version": "0.5.24",
   "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-skills/.claude-plugin/plugin.json
+++ b/plugins/claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-skills/README.md
+++ b/plugins/claude-skills/README.md
@@ -1,4 +1,4 @@
-# claude-skills ![v0.5.23](https://img.shields.io/badge/v0.5.23-blue?style=flat-square)
+# claude-skills ![v0.5.24](https://img.shields.io/badge/v0.5.24-blue?style=flat-square)
 
 Skill and agent authoring tools for Claude Code. Six complementary skills: one generates skills from scratch, one generates agents, one audits skills for structural correctness, one audits agents for structural correctness, one improves skills for effectiveness, and one designs CLI interfaces for the scripts those skills produce. A bundled `skill-lint` agent runs structural linting automatically after skill creation or improvement.
 

--- a/plugins/claude-skills/README.md
+++ b/plugins/claude-skills/README.md
@@ -1,4 +1,4 @@
-# claude-skills ![v0.5.24](https://img.shields.io/badge/v0.5.24-blue?style=flat-square)
+# claude-skills ![v0.5.25](https://img.shields.io/badge/v0.5.25-blue?style=flat-square)
 
 Skill and agent authoring tools for Claude Code. Six complementary skills: one generates skills from scratch, one generates agents, one audits skills for structural correctness, one audits agents for structural correctness, one improves skills for effectiveness, and one designs CLI interfaces for the scripts those skills produce. A bundled `skill-lint` agent runs structural linting automatically after skill creation or improvement.
 

--- a/plugins/claude-skills/skills/create-skill/SKILL.md
+++ b/plugins/claude-skills/skills/create-skill/SKILL.md
@@ -110,7 +110,10 @@ Brief overview (1-2 sentences).
 
 Then add directives like "Summarize this pull request..."
 
-These commands run when the skill is invoked. (The backslashes above escape the backticks so this documentation doesn't execute — in a real skill, write !\`cmd\` without the backslashes.) The model sees only the output — no tool calls needed. Use this for infallible probes (git status, env vars, file trees, process output) where failure is rare and the output is informational. Do not use for commands that may fail or need exit-code branching — those require Bash tool calls so the model can handle errors.
+These commands run when the skill is invoked. The model sees only the output — no tool calls needed. Use this for infallible probes (git status, env vars, file trees, process output) where failure is rare and the output is informational. Do not use for commands that may fail or need exit-code branching — those require Bash tool calls so the model can handle errors.
+
+> **Note:** The backslashes above escape the backticks so this documentation
+> doesn't execute — in a real skill, write !\`cmd\` without the backslashes.
 
 ### Step 5 — Script opportunity scan
 

--- a/plugins/claude-skills/skills/create-skill/SKILL.md
+++ b/plugins/claude-skills/skills/create-skill/SKILL.md
@@ -102,17 +102,15 @@ Brief overview (1-2 sentences).
 | `${CLAUDE_SKILL_DIR}` | Path to the skill's own directory (use for referencing bundled scripts/files) |
 | `${CLAUDE_SESSION_ID}` | Current session ID (useful for logging or session-specific output files) |
 
-**Example — injecting live context:**
+**Example — injecting live context.** In a skill body, write lines like:
 
-```
-- Current branch: !`git branch --show-current`
-- Recent commits: !`git log --oneline -5`
-- Changed files: !`git diff --name-only`
+- Current branch: !\`git branch --show-current\`
+- Recent commits: !\`git log --oneline -5\`
+- Changed files: !\`git diff --name-only\`
 
-Summarize this pull request...
-```
+Then add directives like "Summarize this pull request..."
 
-These commands run when the skill is invoked. The model sees only the output — no tool calls needed. Use this for infallible probes (git status, env vars, file trees, process output) where failure is rare and the output is informational. Do not use for commands that may fail or need exit-code branching — those require Bash tool calls so the model can handle errors.
+These commands run when the skill is invoked. (The backslashes above escape the backticks so this documentation doesn't execute — in a real skill, write !\`cmd\` without the backslashes.) The model sees only the output — no tool calls needed. Use this for infallible probes (git status, env vars, file trees, process output) where failure is rare and the output is informational. Do not use for commands that may fail or need exit-code branching — those require Bash tool calls so the model can handle errors.
 
 ### Step 5 — Script opportunity scan
 

--- a/plugins/claude-skills/skills/create-skill/references/frontmatter-options.md
+++ b/plugins/claude-skills/skills/create-skill/references/frontmatter-options.md
@@ -49,7 +49,7 @@ context: fork                       # Run in a subagent (isolates from conversat
 agent: Explore                      # Subagent type when context: fork (default: general-purpose)
 effort: high                        # Override session effort: low | medium | high | max (max: Opus 4.6 only)
 paths: "*.py,src/**/*.ts"           # Glob patterns limiting auto-activation to matching files
-shell: bash                         # Shell for !`cmd` blocks: bash (default) or powershell
+shell: bash                         # Shell for bang+backtick inline-command blocks: bash (default) or powershell
 
 # Behavior modifiers
 user-invocable: true                # Show in /command menu (default true)
@@ -89,7 +89,7 @@ context: fork                       # Run in a subagent (isolates from conversat
 agent: Explore                      # Subagent type when context: fork (default: general-purpose)
 effort: high                        # Override session effort: low | medium | high | max (max: Opus 4.6 only)
 paths: "*.py,src/**/*.ts"           # Glob patterns limiting auto-activation to matching files
-shell: bash                         # Shell for !`cmd` blocks: bash (default) or powershell
+shell: bash                         # Shell for bang+backtick inline-command blocks: bash (default) or powershell
 
 # Behavior modifiers (commands)
 disable-model-invocation: true      # Prevent programmatic invocation (commands only)
@@ -166,7 +166,7 @@ description: Deploy to staging environment
 
 For `hooks`, `context`, `effort`, and `paths` — see Advanced Field Reference below.
 
-- **`shell`** — Shell for `!`backtick`` and ` ```! ` blocks: bash (default) or powershell. Setting powershell runs inline shell commands via PowerShell on Windows. Requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` env var for inline `!` commands to execute via PowerShell.
+- **`shell`** — Shell for inline !\`cmd\` blocks and ` ```! ` fenced blocks: bash (default) or powershell. Setting powershell runs inline shell commands via PowerShell on Windows. Requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` env var for inline bang-prefix commands to execute via PowerShell.
 
 - **`disable-model-invocation: true`** — Commands only. Prevents Claude from auto-loading based on description. Has no effect on skills — use `user-invocable: false` instead.
 
@@ -186,7 +186,7 @@ These fields add execution control, lifecycle hooks, and platform-specific behav
 
 - **`paths`** — Glob patterns (comma-separated or YAML list) limiting auto-activation. When set, Claude loads the skill automatically only when working with files matching the patterns. Use for language-specific or framework-specific skills.
 
-- **`shell`** — Shell for `!`backtick`` and ` ```! ` blocks: bash (default) or powershell. Setting powershell runs inline shell commands via PowerShell on Windows. Requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` env var for inline `!` commands to execute via PowerShell.
+- **`shell`** — Shell for inline !\`cmd\` blocks and ` ```! ` fenced blocks: bash (default) or powershell. Setting powershell runs inline shell commands via PowerShell on Windows. Requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` env var for inline bang-prefix commands to execute via PowerShell.
 
 - **`disable-model-invocation: true`** — Commands only. Prevents Claude from auto-loading based on description. Has no effect on skills — use `user-invocable: false` instead for skills you want to hide from auto-triggering.
 

--- a/plugins/claude-skills/skills/repair-skill/SKILL.md
+++ b/plugins/claude-skills/skills/repair-skill/SKILL.md
@@ -128,13 +128,14 @@ and tool selection framework.
   2. Run `git diff --name-only` using Bash
   3. Analyze the results...
   ```
-  **After (injected at invocation, zero tool calls):**
-  ```
-  - Recent commits: !`git log --oneline -5`
-  - Changed files: !`git diff --name-only`
+  **After (injected at invocation, zero tool calls).** Replace those Bash calls with:
 
-  Analyze the results...
-  ```
+  - Recent commits: !\`git log --oneline -5\`
+  - Changed files: !\`git diff --name-only\`
+
+  Then continue with prose like "Analyze the results..." (The backslashes escape
+  the backticks so this documentation doesn't execute — in a real skill, write
+  !\`cmd\` without the backslashes.)
 
 ---
 

--- a/plugins/claude-skills/skills/repair-skill/SKILL.md
+++ b/plugins/claude-skills/skills/repair-skill/SKILL.md
@@ -133,9 +133,10 @@ and tool selection framework.
   - Recent commits: !\`git log --oneline -5\`
   - Changed files: !\`git diff --name-only\`
 
-  Then continue with prose like "Analyze the results..." (The backslashes escape
-  the backticks so this documentation doesn't execute — in a real skill, write
-  !\`cmd\` without the backslashes.)
+  Then continue with prose like "Analyze the results..."
+
+  > **Note:** The backslashes escape the backticks so this documentation
+  > doesn't execute — in a real skill, write !\`cmd\` without the backslashes.
 
 ---
 

--- a/plugins/claude-skills/skills/repair-skill/references/frontmatter-options.md
+++ b/plugins/claude-skills/skills/repair-skill/references/frontmatter-options.md
@@ -171,7 +171,7 @@ filter narrows scope, so the description should match that narrowed scope.
 
 ### `shell` (string)
 
-Shell for `!`backtick`` and ` ```! ` blocks: `bash` (default) or `powershell`. Only
+Shell for inline !\`cmd\` blocks and ` ```! ` fenced blocks: `bash` (default) or `powershell`. Only
 relevant for skills using inline shell execution.
 
 ---


### PR DESCRIPTION
## Summary
- docs(skills): escape bang-backtick patterns in create-skill and repair-skill docs
- docs(memory): remove stray closing fence in extract-learnings SKILL.md

## Changes
- `.claude-plugin/marketplace.json`
- `README.md`
- `plugins/claude-memory/.claude-plugin/plugin.json`
- `plugins/claude-memory/README.md`
- `plugins/claude-memory/skills/extract-learnings/SKILL.md`
- `plugins/claude-skills/.claude-plugin/plugin.json`
- `plugins/claude-skills/README.md`
- `plugins/claude-skills/skills/create-skill/SKILL.md`
- `plugins/claude-skills/skills/create-skill/references/frontmatter-options.md`
- `plugins/claude-skills/skills/repair-skill/SKILL.md`
- _1 generated/lock files omitted_

## Commits
- `9a9022f` docs(skills): escape bang-backtick patterns in create-skill and repair-skill docs
- `ad71123` docs(memory): remove stray closing fence in extract-learnings SKILL.md

## Diff Stat
\`\`\`
.claude-plugin/marketplace.json                            |  4 ++--
 README.md                                                  |  4 ++--
 plugins/claude-memory/.claude-plugin/plugin.json           |  2 +-
 plugins/claude-memory/README.md                            |  2 +-
 plugins/claude-memory/skills/extract-learnings/SKILL.md    |  1 -
 plugins/claude-skills/.claude-plugin/plugin.json           |  2 +-
 plugins/claude-skills/README.md                            |  2 +-
 plugins/claude-skills/skills/create-skill/SKILL.md         | 14 ++++++--------
 .../skills/create-skill/references/frontmatter-options.md  |  8 ++++----
 plugins/claude-skills/skills/repair-skill/SKILL.md         | 13 +++++++------
 .../skills/repair-skill/references/frontmatter-options.md  |  2 +-
 11 files changed, 26 insertions(+), 28 deletions(-)
\`\`\`