### PR TITLE
fix(get-pr-comments): surfacing full bot reviews and outdated inline comments

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.47",
+      "version": "0.2.48",
       "source": "./plugins/claude-coding"
     },
     {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.47](https://img.shields.io/badge/v0.2.47-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.48](https://img.shields.io/badge/v0.2.48-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and two agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.47](https://img.shields.io/badge/v0.2.47-blue?style=flat-square)
+# claude-coding ![v0.2.48](https://img.shields.io/badge/v0.2.48-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Eight skills and one command covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/skills/get-pr-comments/scripts/fetch_pr_comments.py
+++ b/plugins/claude-coding/skills/get-pr-comments/scripts/fetch_pr_comments.py
@@ -115,7 +115,6 @@ def fetch_inline_comments(pr_number: int, repo: str | None) -> list[dict]:
             "commit_id": c.get("commit_id", ""),
         }
         for c in items
-        if c.get("position") is not None
     ]
 
 
@@ -138,9 +137,12 @@ INLINE_SEVERITY_PATTERNS = [
     (re.compile(r"!\[P1[^\]]*\]", re.IGNORECASE), "must_fix"),
     (re.compile(r"\*\*P1\*\*", re.IGNORECASE), "must_fix"),
     (re.compile(r"\bmust[- ]fix\b|\bblocking\b|\bcritical\b|\brequired\b", re.IGNORECASE), "must_fix"),
+    (re.compile(r"🔴|🟠"), "must_fix"),
     (re.compile(r"!\[P2[^\]]*\]", re.IGNORECASE), "optional"),
     (re.compile(r"\*\*P2\*\*", re.IGNORECASE), "optional"),
     (re.compile(r"\boptional\b|\bsuggestion\b|\bnit\b|\bminor\b|\bnon-blocking\b", re.IGNORECASE), "optional"),
+    (re.compile(r"🟡\s*STILL OPEN", re.IGNORECASE), "optional"),
+    (re.compile(r"🟢"), "optional"),
 ]
 
 
@@ -164,6 +166,68 @@ def _extract_section_key(section: str) -> str:
         if line and not line.startswith("#"):
             return _normalize_key(line[:80])
     return _normalize_key(section[:80])
+
+
+# Emoji markers used by claude[bot] and similar review bots.
+_EMOJI_MUST_FIX = re.compile(r"^(🔴|🟠)", re.MULTILINE)
+_EMOJI_OPTIONAL_OPEN = re.compile(r"^🟡\s*STILL OPEN", re.MULTILINE | re.IGNORECASE)
+_EMOJI_OPTIONAL_NEW = re.compile(r"^🟢", re.MULTILINE)
+_EMOJI_RESOLVED = re.compile(r"^✅\s*RESOLVED", re.MULTILINE | re.IGNORECASE)
+# Any emoji marker line (used to detect the boundary of the current item)
+_EMOJI_MARKER = re.compile(r"^(🔴|🟠|🟡|🟢|✅)", re.MULTILINE)
+# Section header or horizontal rule — also terminates an emoji item
+_SECTION_BREAK = re.compile(r"^(#{1,3}\s|---+\s*$)", re.MULTILINE)
+
+
+def _extract_emoji_items(body: str) -> dict:
+    """Extract actionable items denoted by leading emoji markers.
+
+    Scans line-by-line for lines beginning with a recognised emoji prefix.
+    Accumulates subsequent lines as the item body until the next emoji marker
+    or a section break (header / horizontal rule). Returns a dict with
+    ``must_fix`` and ``optional`` lists; resolved items (✅) are skipped.
+    """
+    items: dict[str, list[str]] = {"must_fix": [], "optional": []}
+
+    lines = body.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # Determine severity from the opening emoji
+        if _EMOJI_MUST_FIX.match(stripped):
+            severity = "must_fix"
+        elif _EMOJI_OPTIONAL_OPEN.match(stripped) or _EMOJI_OPTIONAL_NEW.match(stripped):
+            severity = "optional"
+        elif _EMOJI_RESOLVED.match(stripped):
+            # Skip resolved items — advance past their body
+            i += 1
+            while i < len(lines):
+                next_stripped = lines[i].strip()
+                if _EMOJI_MARKER.match(next_stripped) or _SECTION_BREAK.match(next_stripped):
+                    break
+                i += 1
+            continue
+        else:
+            i += 1
+            continue
+
+        # Collect the marker line plus continuation lines
+        item_lines = [stripped]
+        i += 1
+        while i < len(lines):
+            next_stripped = lines[i].strip()
+            if _EMOJI_MARKER.match(next_stripped) or _SECTION_BREAK.match(next_stripped):
+                break
+            item_lines.append(next_stripped)
+            i += 1
+
+        item_text = "\n".join(ln for ln in item_lines if ln)
+        if item_text:
+            items[severity].append(item_text)
+
+    return items
 
 
 def extract_sections(body: str) -> dict:
@@ -195,6 +259,11 @@ def extract_sections(body: str) -> dict:
             sections["must_fix"].append(part_stripped)
         elif is_optional:
             sections["optional"].append(part_stripped)
+
+    # Also extract emoji-prefixed items (e.g. from claude[bot] structured reviews)
+    emoji_items = _extract_emoji_items(body)
+    sections["must_fix"].extend(emoji_items["must_fix"])
+    sections["optional"].extend(emoji_items["optional"])
 
     return sections
 
@@ -349,7 +418,7 @@ def build_result(pr_number: int, repo: str | None) -> dict:
     }
 
 
-BOT_BODY_LIMIT = 300  # max chars for bot comment bodies
+BOT_BODY_LIMIT = 3000  # max chars for bot comment bodies
 
 
 def _short_date(ts: str) -> str:

--- a/plugins/claude-coding/skills/get-pr-comments/scripts/fetch_pr_comments.py
+++ b/plugins/claude-coding/skills/get-pr-comments/scripts/fetch_pr_comments.py
@@ -180,13 +180,8 @@ _SECTION_BREAK = re.compile(r"^(#{1,3}\s|---+\s*$)", re.MULTILINE)
 
 
 def _extract_emoji_items(body: str) -> dict:
-    """Extract actionable items denoted by leading emoji markers.
-
-    Scans line-by-line for lines beginning with a recognised emoji prefix.
-    Accumulates subsequent lines as the item body until the next emoji marker
-    or a section break (header / horizontal rule). Returns a dict with
-    ``must_fix`` and ``optional`` lists; resolved items (✅) are skipped.
-    """
+def _extract_emoji_items(body: str) -> dict[str, list[str]]:
+    """Extract must_fix/optional items from leading emoji markers; skips ✅ RESOLVED."""
     items: dict[str, list[str]] = {"must_fix": [], "optional": []}
 
     lines = body.splitlines()

--- a/plugins/claude-coding/skills/get-pr-comments/scripts/fetch_pr_comments.py
+++ b/plugins/claude-coding/skills/get-pr-comments/scripts/fetch_pr_comments.py
@@ -169,14 +169,14 @@ def _extract_section_key(section: str) -> str:
 
 
 # Emoji markers used by claude[bot] and similar review bots.
-_EMOJI_MUST_FIX = re.compile(r"^(🔴|🟠)", re.MULTILINE)
-_EMOJI_OPTIONAL_OPEN = re.compile(r"^🟡\s*STILL OPEN", re.MULTILINE | re.IGNORECASE)
-_EMOJI_OPTIONAL_NEW = re.compile(r"^🟢", re.MULTILINE)
-_EMOJI_RESOLVED = re.compile(r"^✅\s*RESOLVED", re.MULTILINE | re.IGNORECASE)
+_EMOJI_MUST_FIX = re.compile(r"^(🔴|🟠)")
+_EMOJI_OPTIONAL_OPEN = re.compile(r"^🟡\s*STILL OPEN", re.IGNORECASE)
+_EMOJI_OPTIONAL_NEW = re.compile(r"^🟢")
+_EMOJI_RESOLVED = re.compile(r"^✅\s*RESOLVED", re.IGNORECASE)
 # Any emoji marker line (used to detect the boundary of the current item)
-_EMOJI_MARKER = re.compile(r"^(🔴|🟠|🟡|🟢|✅)", re.MULTILINE)
+_EMOJI_MARKER = re.compile(r"^(🔴|🟠|🟡|🟢|✅)")
 # Section header or horizontal rule — also terminates an emoji item
-_SECTION_BREAK = re.compile(r"^(#{1,3}\s|---+\s*$)", re.MULTILINE)
+_SECTION_BREAK = re.compile(r"^(#{1,3}\s|---+\s*$)")
 
 
 def _extract_emoji_items(body: str) -> dict:


### PR DESCRIPTION
## Summary

- **Raise BOT_BODY_LIMIT 300 → 3000**: Known review bots (claude[bot], chatgpt-codex-connector[bot]) post long structured reviews as issue_comments; the old 300-char cap silently truncated the bulk of their feedback.
- **Emoji actionable patterns**: claude[bot] uses emoji markers (`🔴`/`🟠` → must_fix, `🟡 STILL OPEN`/`🟢` → optional, `✅ RESOLVED` → skip) rather than `### Must Fix` / `### Optional` headers. Added `_extract_emoji_items()` helper called from `extract_sections()` to recognise these, and added the same emoji patterns to `INLINE_SEVERITY_PATTERNS` for inline comment classification.
- **Keep outdated inline comments**: `fetch_inline_comments` filtered out comments where GitHub had nulled `position` (happens when new commits are pushed after the comment). These comments are still valuable; the existing `stale` flag (computed via `commit_id != head_sha`) already handles the staleness indication downstream.

## Test plan

- [x] `python3 fetch_pr_comments.py --help` exits 0 and prints usage
- [x] AST parse passes (`python3 -c "import ast; ast.parse(open('fetch_pr_comments.py').read())"`)
- [x] Run against a real PR that has claude[bot] review comments; confirm emoji items appear in MUST FIX / OPTIONAL sections
- [x] Run against a PR with outdated inline comments (position=null); confirm they appear with `[against older commit]` tag rather than being dropped