### PR TITLE
docs(generate-image): generalize multi-reference patterns; add constraint-locking primitive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
     {
       "name": "claude-content",
       "description": "Content creation skills: image generation, video compression, conversion, GIF creation, social media formatting, and audio extraction",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "source": "./plugins/claude-content"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
     {
       "name": "claude-content",
       "description": "Content creation skills: image generation, video compression, conversion, GIF creation, social media formatting, and audio extraction",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "source": "./plugins/claude-content"
     },
     {

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Structured thinking and multi-perspective deliberation tools for Claude Code.
 
 <a id="claude-content"></a>
 
-### 🎬 claude-content &nbsp; ![v0.4.12](https://img.shields.io/badge/v0.4.12-blue?style=flat-square)
+### 🎬 claude-content &nbsp; ![v0.4.13](https://img.shields.io/badge/v0.4.13-blue?style=flat-square)
 
 Content creation and processing tools for Claude Code. Image generation and the full video/audio manipulation workflow.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Structured thinking and multi-perspective deliberation tools for Claude Code.
 
 <a id="claude-content"></a>
 
-### 🎬 claude-content &nbsp; ![v0.4.13](https://img.shields.io/badge/v0.4.13-blue?style=flat-square)
+### 🎬 claude-content &nbsp; ![v0.4.14](https://img.shields.io/badge/v0.4.14-blue?style=flat-square)
 
 Content creation and processing tools for Claude Code. Image generation and the full video/audio manipulation workflow.
 

--- a/plugins/claude-content/.claude-plugin/plugin.json
+++ b/plugins/claude-content/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-content",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Content creation skills: image generation, video compression, conversion, GIF creation, social media formatting, audio extraction, and shot frame extraction",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-content/.claude-plugin/plugin.json
+++ b/plugins/claude-content/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-content",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Content creation skills: image generation, video compression, conversion, GIF creation, social media formatting, audio extraction, and shot frame extraction",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-content/README.md
+++ b/plugins/claude-content/README.md
@@ -1,4 +1,4 @@
-# claude-content ![v0.4.12](https://img.shields.io/badge/v0.4.12-blue?style=flat-square)
+# claude-content ![v0.4.13](https://img.shields.io/badge/v0.4.13-blue?style=flat-square)
 
 Content creation and processing tools for Claude Code. Seven skills covering image generation, video manipulation, social media formatting, audio extraction, and shot frame extraction.
 

--- a/plugins/claude-content/README.md
+++ b/plugins/claude-content/README.md
@@ -1,4 +1,4 @@
-# claude-content ![v0.4.13](https://img.shields.io/badge/v0.4.13-blue?style=flat-square)
+# claude-content ![v0.4.14](https://img.shields.io/badge/v0.4.14-blue?style=flat-square)
 
 Content creation and processing tools for Claude Code. Seven skills covering image generation, video manipulation, social media formatting, audio extraction, and shot frame extraction.
 

--- a/plugins/claude-content/skills/generate-image/SKILL.md
+++ b/plugins/claude-content/skills/generate-image/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: generate-image
 description: >
-  This skill should be used when the user asks to "generate an image",
-  "create a picture", "make me a logo", "edit this image", "combine
-  these images", "make a sticker", "product mockup", "use nano banana",
-  or any image creation/manipulation request. Covers t2i, i2i, and
-  multi-reference composition end-to-end via the generate.py script.
-  Not for HTML/CSS mockups, data visualizations, diagrams, or coded
-  UI components.
+  Use for any image creation or editing request — logo, sticker, product
+  mockup, nano banana, t2i, i2i, multi-reference compositing via generate.py.
+  Not for HTML/CSS mockups, diagrams, or coded UI.
 allowed-tools:
   - Bash(uv:*)
   - Read
@@ -19,7 +15,7 @@ Requires `GEMINI_API_KEY` environment variable and `uv` package manager.
 ## Workflow
 
 1. **Understand** — Determine mode (t2i, i2i, multi-reference), gather parameters (model, aspect ratio, resolution, output path). If the prompt requires precise execution (specific pose, asymmetric framing, exact crop), default to `--batch 3` or `--batch 4` and surface this to the user — image generation is stochastic and precise directives hit ~50% per seed. Exit: mode, parameters, and batch size are clear.
-2. **Craft prompt** — Apply the prompting principles below to write the prompt. For t2i, use narrative prose. For i2i/multi-reference, use directive grammar with reference blocks. Exit: prompt is written and follows the relevant checklist.
+2. **Craft prompt** — Default to the minimal prompt that can carry the intent: t2i uses narrative prose; i2i/multi-reference uses a reference block plus the minimal directive. Apply the **Core** checklist (always, for the matching mode). Reach into the **Escalation toolkit** only on a known-hard signature — a detail/geometry-fidelity shot — or after a batch shows drift; then add only the specific lock for the attribute that is drifting, not the whole kit. Over-constraining a simple edit degrades it as surely as under-specifying a complex one. Exit: prompt written, Core items satisfied, escalation tools added only where a signature or observed drift justifies them.
 3. **Confirm** — Show the user the exact prompt, input images (if any), model, resolution, aspect ratio, and batch size. Ask for confirmation. Exit: user approves.
 4. **Generate** — Run the script with confirmed parameters. Exit: images are saved and displayed.
 5. **Iterate** — Present results and evaluate against intent before offering refinements. Evaluation order by mode: **t2i** — subject correctness, composition, style fidelity. **i2i edit** — the changed element looks right, nothing else changed. **Multi-reference composition** — the primary transferred attribute matches its source reference FIRST (for a detail shot, the construction geometry — width, edge shape, count, angle), secondary consistency (identity, environment) holds SECOND, staging (lighting, composition, framing) THIRD. Decide what's primary per task. Cherry-pick the winning frame from the batch rather than re-prompting for consistency past ~75%. Exit: user is satisfied or moves on.
@@ -188,32 +184,35 @@ The script auto-detects resolution and aspect ratio from input images when flags
 
 ## Pre-Generation Checklist
 
-**Before generating (t2i):**
+Core items are the floor — apply them to every prompt of the matching mode. The Escalation toolkit is opt-in: skip it entirely for simple t2i and single-element edits. Reach in only on a known-hard signature (a detail/geometry-fidelity shot) or after a batch shows drift — and then add only the lock for the attribute that is actually drifting. Each added constraint costs fidelity on everything else, so escalation scales with how many independent things can drift, not with how ambitious the prompt is.
+
+### Core — t2i (always)
 - [ ] Narrative description (not keyword list)?
 - [ ] Positive framing throughout — no "no X" / "not X" / "do not X" clauses anywhere in the prompt?
 - [ ] Camera/lighting details for photorealism?
-- [ ] Text in quotes, font style described?
+- [ ] Text in quotes, font style described? (if the image has text)
 - [ ] Aspect ratio appropriate for use case?
 - [ ] Model choice appropriate? (Nano Banana default; Nano Banana Pro for max quality)
 - [ ] Thinking level set for complex prompts? (Nano Banana only)
 - [ ] Batch size matches precision needs? (`--batch 3` or `--batch 4` for precise pose / framing / asymmetric directives)
 
-**Before editing (i2i / multi-reference):**
+### Core — i2i / multi-reference (always)
 - [ ] Reference block at start of prompt labeling each image's role?
-- [ ] Prompt directs rather than describes?
+- [ ] Reference roles positive-only — lists what to USE from each ref, never what to ignore? (see editing-guide.md "Reference Block")
 - [ ] Minimal directive pattern? (Reference block + one Replace directive — no "do not change anything else" stop clause, no decorative preservation clauses)
-- [ ] Reference role scoping is positive-only? (lists what to USE from each ref, never what to ignore — see editing-guide.md "Reference Block")
-- [ ] Positive framing throughout the directive? (no negation in critical sections, geometry locks, or composition locks)
-- [ ] For 3+ references, using per-reference role assignment? (one sentence assigning each image its contribution — see editing-guide.md "Per-Reference Role Assignment")
-- [ ] For Nano Banana + thinking high with 3+ references, included the inventory preamble? ("Silently inventory the design-critical details: ...")
-- [ ] Base image is first in `--input` list (Image 1)?
-- [ ] Prompt image labels match input order? (base = Image 1 = first input, references numbered after — mislabeled roles cause character drift)
+- [ ] Positive framing throughout the directive? (no negation anywhere, including locks and composition clauses)
+- [ ] Base image first in `--input` (Image 1), and prompt labels match input order? (mislabeled roles cause character drift)
+- [ ] Only one change per prompt? (split competing directives into sequential passes)
 - [ ] When extracting/transferring elements: explicitly named each element rather than generic "outfit/object from image X"?
 - [ ] No color labels competing with reference image? (color words override visual reference — see editing-guide)
 - [ ] Base image has minimal accessories that could contaminate? (bags, hats, sunglasses bleed into output)
-- [ ] Only one change per prompt? (split competing directives into sequential passes)
 - [ ] Reference count within model limits? (Nano Banana: 14, Nano Banana Pro: 11)
-- [ ] For complex/multi-reference shots: locked each *drifting* attribute in its own `## CRITICAL —` section (identity, skin & finish, lighting/color, geometry, orientation), without over-constraining the stable ones? (see editing-guide.md "Constraint Locking with CRITICAL Sections")
-- [ ] For photorealistic human shots: skin & finish locked? (generative skin drifts to plastic/retouched — a near-universal lock)
-- [ ] For detail shots: geometry locked via per-attribute enumeration, not generic "match exactly"? (see capability-patterns.md "Geometry Lock for Detail Shots")
-- [ ] For follow-up shots from the same set: continuity assertion included? ("from the same set as Image N: same subject, same setting, same light" — see editing-guide.md "Continuity Assertion")
+- [ ] For 3+ references: per-reference role-assignment sentence? (one sentence assigning each image its contribution — see editing-guide.md "Per-Reference Role Assignment")
+- [ ] For photorealistic human shots: skin & finish locked? (the one near-universal CRITICAL section — generative skin drifts to plastic/retouched)
+
+### Escalation toolkit — reach for only on a hard signature or observed drift
+- [ ] An attribute (identity, lighting/color, orientation, drape) drifting across the batch? Lock that *specific* attribute in its own `## CRITICAL —` section, positively phrased — without over-constraining the stable ones. (see editing-guide.md "Constraint Locking with CRITICAL Sections")
+- [ ] Detail shot whose construction won't hold? Geometry lock via per-attribute enumeration, not generic "match exactly". (see capability-patterns.md "Geometry Lock for Detail Shots")
+- [ ] Nano Banana + `--thinking high` with 3+ references and weak adherence? Add the inventory preamble. ("Silently inventory the design-critical details: ...")
+- [ ] Follow-up shot from the same set? Continuity assertion. ("from the same set as Image N: same subject, same setting, same light" — see editing-guide.md "Continuity Assertion")
+- [ ] Campaign with a locked hero image? Collapse to two-input form — hero as bundle-source + the single new-attribute reference. (see editing-guide.md "Single-Reference Collapse")

--- a/plugins/claude-content/skills/generate-image/SKILL.md
+++ b/plugins/claude-content/skills/generate-image/SKILL.md
@@ -5,8 +5,9 @@ description: >
   "create a picture", "make me a logo", "edit this image", "combine
   these images", "make a sticker", "product mockup", "use nano banana",
   or any image creation/manipulation request. Covers t2i, i2i, and
-  multi-reference composition. Not for HTML/CSS mockups, data
-  visualizations, diagrams, or coded UI components.
+  multi-reference composition end-to-end via the generate.py script.
+  Not for HTML/CSS mockups, data visualizations, diagrams, or coded
+  UI components.
 allowed-tools:
   - Bash(uv:*)
   - Read
@@ -17,11 +18,11 @@ Requires `GEMINI_API_KEY` environment variable and `uv` package manager.
 
 ## Workflow
 
-1. **Understand** — Determine mode (t2i, i2i, multi-reference), gather parameters (model, aspect ratio, resolution, output path). Exit: mode and parameters are clear.
+1. **Understand** — Determine mode (t2i, i2i, multi-reference), gather parameters (model, aspect ratio, resolution, output path). If the prompt requires precise execution (specific pose, asymmetric framing, exact crop), default to `--batch 3` or `--batch 4` and surface this to the user — image generation is stochastic and precise directives hit ~50% per seed. Exit: mode, parameters, and batch size are clear.
 2. **Craft prompt** — Apply the prompting principles below to write the prompt. For t2i, use narrative prose. For i2i/multi-reference, use directive grammar with reference blocks. Exit: prompt is written and follows the relevant checklist.
-3. **Confirm** — Show the user the exact prompt, input images (if any), model, resolution, and aspect ratio. Ask for confirmation. Exit: user approves.
+3. **Confirm** — Show the user the exact prompt, input images (if any), model, resolution, aspect ratio, and batch size. Ask for confirmation. Exit: user approves.
 4. **Generate** — Run the script with confirmed parameters. Exit: images are saved and displayed.
-5. **Iterate** — Present results. Offer refinements (prompt tweaks, parameter changes, follow-up edits). Exit: user is satisfied or moves on.
+5. **Iterate** — Present results and evaluate against intent before offering refinements. Evaluation order by mode: **t2i** — subject correctness, composition, style fidelity. **i2i edit** — the changed element looks right, nothing else changed. **Multi-reference composition** — the primary transferred attribute matches its source reference FIRST (for a detail shot, the construction geometry — width, edge shape, count, angle), secondary consistency (identity, environment) holds SECOND, staging (lighting, composition, framing) THIRD. Decide what's primary per task. Cherry-pick the winning frame from the batch rather than re-prompting for consistency past ~75%. Exit: user is satisfied or moves on.
 
 ## Default Output & Logging
 
@@ -38,7 +39,7 @@ When gathering parameters (aspect ratio, resolution), offer the option to specif
 
 ## Core Prompting Principle
 
-Describe scenes narratively, not as keyword lists. Gemini's language model parses prose with full semantic understanding — narrative prompts encode spatial relationships, mood, and intent that comma-separated tags cannot express. Tag-style prompts lose compositional meaning and produce generic results.
+**Describe scenes narratively, not as keyword lists.** Gemini's language model parses prose with full semantic understanding — narrative prompts encode spatial relationships, mood, and intent that comma-separated tags cannot express. Tag-style prompts lose compositional meaning and produce generic results.
 
 ```
 Bad:  "cat, wizard hat, magical, fantasy, 4k, detailed"
@@ -47,6 +48,19 @@ Good: "A fluffy orange tabby sits regally on a velvet cushion, wearing an ornate
        purple wizard hat embroidered with silver stars. Soft candlelight illuminates
        the scene from the left. The mood is whimsical yet dignified."
 ```
+
+**Describe positively, never via negation.** Every concept named in a prompt biases the output toward that concept — even when preceded by "not", "no", or "do not". Diffusion models condition on tokens regardless of polarity. To exclude X, either (a) name a positive alternative that fills the same role, or (b) scope the prompt so X has no place to land.
+
+```
+Bad:   "A clean studio backdrop. No warm tones, no cream, no beige, no tan."
+Good:  "A clean cool-neutral gray studio backdrop with subtle blue undertones."
+
+Bad:   "A headshot with no harsh shadows on the face, no distracting background."
+Good:  "A headshot on a clean neutral gray backdrop, even soft frontal fill light
+        that flatters the face."
+```
+
+This rule applies everywhere in the skill — t2i prompts, i2i directives, reference role descriptions, and framing instructions.
 
 A useful formula: `[Subject] doing [Action] in [Context]. [Camera/Composition]. [Lighting]. [Style]. [Constraint].` Not every prompt needs every element — match detail to intent. If the user has a specific vision, be prescriptive (exact descriptions); if exploring, be open (general direction, let the model decide details). Ask if unclear.
 
@@ -58,7 +72,7 @@ A useful formula: `[Subject] doing [Action] in [Context]. [Camera/Composition]. 
 
 **Step-by-step instructions**: For complex scenes, break the prompt into sequential directives. "Start with a wide desert landscape. Place a lone figure walking left-to-right in the lower third. Behind them, a massive sandstorm approaches from the right."
 
-**Semantic negative prompts**: State what to avoid using natural language. "No text overlays, no watermarks, no humans in the background" is more effective than trying to describe only what you want when exclusions matter.
+**Exclusion via positive constraint**: When something must be absent from the output, do not name it under a negation. Either name a positive alternative ("clean unbranded surface" instead of "no logos") or scope the scene so the unwanted element has no place to land ("a closed laptop on the desk" makes a screen impossible to render). Naming X under "no X" makes X more likely, not less.
 
 **Camera control**: Specify shot type (extreme close-up, medium shot, aerial), lens (fisheye, telephoto), and camera angle (low angle, bird's eye, Dutch angle) to control framing precisely.
 
@@ -68,7 +82,9 @@ Editing with reference images follows different principles — see [references/e
 
 ## Key Editing Principles
 
-Editing prompts direct changes rather than describing scenes. Point to what the model can see; describe only what it cannot. Specify intentionally — every adjective, color word, or preservation clause beyond the minimum competes with the reference image and degrades fidelity. The reliable shape is a reference block, one Replace directive, and "Do not change anything else." — details in editing-guide.md.
+Editing prompts direct changes rather than describing scenes. Point to what the model can see; describe only what it cannot. Specify intentionally — every adjective, color word, or preservation clause beyond the minimum competes with the reference image and degrades fidelity. The reliable shape is a reference block plus one Replace directive — the verb's implicit scope handles preservation, no stop clause needed. Details in editing-guide.md.
+
+For multi-reference work (3+ images), use per-reference role assignment: one sentence that assigns each reference its specific contribution ("the facade from Image 2; the car from Image 3; the sky and lighting from Image 1") — see editing-guide.md "Per-Reference Role Assignment".
 
 Base image goes first in `--input` — it becomes Image 1 in the prompt. Gemini numbers images sequentially from input order. Reference block labels must match input order exactly.
 
@@ -174,16 +190,22 @@ The script auto-detects resolution and aspect ratio from input images when flags
 
 **Before generating (t2i):**
 - [ ] Narrative description (not keyword list)?
+- [ ] Positive framing throughout — no "no X" / "not X" / "do not X" clauses anywhere in the prompt?
 - [ ] Camera/lighting details for photorealism?
 - [ ] Text in quotes, font style described?
 - [ ] Aspect ratio appropriate for use case?
 - [ ] Model choice appropriate? (Nano Banana default; Nano Banana Pro for max quality)
 - [ ] Thinking level set for complex prompts? (Nano Banana only)
+- [ ] Batch size matches precision needs? (`--batch 3` or `--batch 4` for precise pose / framing / asymmetric directives)
 
 **Before editing (i2i / multi-reference):**
 - [ ] Reference block at start of prompt labeling each image's role?
 - [ ] Prompt directs rather than describes?
-- [ ] Minimal directive pattern? (Reference block + one Replace directive + "Do not change anything else." — no decorative preservation clauses)
+- [ ] Minimal directive pattern? (Reference block + one Replace directive — no "do not change anything else" stop clause, no decorative preservation clauses)
+- [ ] Reference role scoping is positive-only? (lists what to USE from each ref, never what to ignore — see editing-guide.md "Reference Block")
+- [ ] Positive framing throughout the directive? (no negation in critical sections, geometry locks, or composition locks)
+- [ ] For 3+ references, using per-reference role assignment? (one sentence assigning each image its contribution — see editing-guide.md "Per-Reference Role Assignment")
+- [ ] For Nano Banana + thinking high with 3+ references, included the inventory preamble? ("Silently inventory the design-critical details: ...")
 - [ ] Base image is first in `--input` list (Image 1)?
 - [ ] Prompt image labels match input order? (base = Image 1 = first input, references numbered after — mislabeled roles cause character drift)
 - [ ] When extracting/transferring elements: explicitly named each element rather than generic "outfit/object from image X"?
@@ -191,3 +213,7 @@ The script auto-detects resolution and aspect ratio from input images when flags
 - [ ] Base image has minimal accessories that could contaminate? (bags, hats, sunglasses bleed into output)
 - [ ] Only one change per prompt? (split competing directives into sequential passes)
 - [ ] Reference count within model limits? (Nano Banana: 14, Nano Banana Pro: 11)
+- [ ] For complex/multi-reference shots: locked each *drifting* attribute in its own `## CRITICAL —` section (identity, skin & finish, lighting/color, geometry, orientation), without over-constraining the stable ones? (see editing-guide.md "Constraint Locking with CRITICAL Sections")
+- [ ] For photorealistic human shots: skin & finish locked? (generative skin drifts to plastic/retouched — a near-universal lock)
+- [ ] For detail shots: geometry locked via per-attribute enumeration, not generic "match exactly"? (see capability-patterns.md "Geometry Lock for Detail Shots")
+- [ ] For follow-up shots from the same set: continuity assertion included? ("from the same set as Image N: same subject, same setting, same light" — see editing-guide.md "Continuity Assertion")

--- a/plugins/claude-content/skills/generate-image/references/capability-patterns.md
+++ b/plugins/claude-content/skills/generate-image/references/capability-patterns.md
@@ -86,15 +86,21 @@ Complex scenes benefit from sequential directives rather than a single compound 
  The water is perfectly still, creating mirror reflections."
 ```
 
-### Semantic Negative Prompts
+### Positive Framing for Exclusions
 
-Describe what to exclude using natural language rather than trying to specify only what you want.
+Naming a concept under negation ("no X", "not X") biases the output toward X — diffusion models condition on tokens regardless of polarity. To exclude something, name a positive alternative that fills the same role, or scope the scene so the unwanted element is physically not there.
 
 ```
-"A professional headshot on a neutral gray backdrop.
- No distracting background elements, no visible logos or text,
- no harsh shadows on the face."
+Bad:   "A professional headshot on a neutral gray backdrop.
+        No distracting background elements, no visible logos or text,
+        no harsh shadows on the face."
+
+Good:  "A professional headshot on a clean seamless gray backdrop,
+        even soft frontal fill light that flatters the face, the
+        wall-to-floor falloff smooth and uncluttered."
 ```
+
+The Good version states what's there, not what isn't. "Clean seamless" implies absence of distraction. "Even soft frontal fill" implies absence of harsh shadows. The model never has to suppress a named concept.
 
 ### Camera Control
 
@@ -120,14 +126,16 @@ The base image matters as much as the prompt. Choose bases where:
 
 ### Garment Swap Prompts
 
-Use the reference block to label the image's role. Do not describe the garment's color, cut, or texture in the directive — those come from the reference image.
+Use the reference block to label the image's role. Let the reference image carry color, cut, and texture — naming those attributes in the directive creates competing signals against the reference pixels.
 
 ```
 Image 1: Base scene
 Image 2: Reference shirt
 
-Replace only the shirt on the mannequin with the blouse from Image 2. Do not change anything else.
+Replace only the shirt on the mannequin with the blouse from Image 2.
 ```
+
+No stop clause — `Replace` already scopes the edit in place. See editing-guide.md "Minimal Directive Pattern".
 
 ### Texture and Fabric
 
@@ -139,6 +147,63 @@ When changing outfit plus accessories or garment plus signage, split into passes
 - Garment swap first, then sign/easel text edit
 - Outfit replacement first, then accessory adjustment
 - Subject compositing first, then pose refinement
+
+### Multi-Reference Fashion Directive
+
+The fashion instance of Per-Reference Role Assignment (editing-guide.md). When composing a full look from a face reference, separate garment references, and a lighting/backdrop plate, assign each reference its contribution in one positive sentence:
+
+```
+Perfectly replicate the exact features of the man's face from Image 2; the exact
+shirt, trouser, belt, and shoe construction and color from Image 3; the cuff and
+collar construction from Images 4 and 5; the cotton weave and sheen from Image 6;
+and the lighting, backdrop, and photographic finish from Image 1.
+```
+
+Each image gets a positively-named job, attributes are enumerated per image (not "the outfit"), and replication verbs ("perfectly replicate", "exact") carry positive intensity with zero negation. For the structural breakdown, see editing-guide.md "Per-Reference Role Assignment".
+
+### Detail Shots (fashion instance of Single-Reference Collapse)
+
+This is the fashion application of Single-Reference Collapse (editing-guide.md). Once a hero image is locked for a campaign, every follow-up detail shot collapses to two-input form: the hero PNG as Image 1 (in this campaign the hero front shot was the bundle-source — it encoded the model's identity, the studio lighting, color science, backdrop, and wardrobe color), plus the single raw construction reference for the detail being shown (cuff macro, collar close-up, weave swatch). The character sheet and the separate lighting reference get dropped — the hero already carries what they contributed.
+
+```
+Inputs (order matters — base first):
+  Image 1: final/<colorway>/front.png        ← bundle-source for everything locked this campaign
+  Image 2: raw/<colorway>/Cuff.jpg           ← scoped to the construction detail being shown
+
+Settings: --model nano-banana --thinking high --resolution 2K --batch 3 --aspect 3:4
+Expected yield: 2/4 keepers (detail crops are simpler than full-body)
+```
+
+Which reference is the bundle-source is a per-campaign choice, not a fixed rule — here it was the hero front shot. This two-input form outperformed the original six-reference setup for detail shots because there were fewer competing signals. Anchor the detail shot to the bundle-source with a continuity assertion (editing-guide.md) and lock the construction with geometry enumeration (below).
+
+### Geometry Lock for Detail Shots
+
+The fashion instance of Geometry Enumeration (editing-guide.md). Generic "match Image 2 exactly" does not preserve specific geometric attributes — the model interprets "exactly" aspirationally and width, edge shape, button count, and point spread all drift seed-to-seed. To lock garment geometry, enumerate each attribute explicitly in a dedicated `CRITICAL — Geometry match` section, named positively.
+
+Canonical attributes by garment region:
+
+| Region | Attributes to enumerate |
+|---|---|
+| **Cuff** | Width relative to wrist (e.g., 1.4–1.5x wrist circumference), edge shape (horizontal straight perpendicular to sleeve, sharp 90° corners), button count and placement (one at wrist edge, one on gauntlet placket above), topstitching gauge |
+| **Collar** | Type (point / spread / cutaway / band / mandarin — name the one you want), point length (short / moderate / long), spread angle in degrees, stand height, top button position (visible at base of stand when fastened), placket type |
+| **Placket** | Type (clean front / button-band / hidden), topstitching style (single-needle / double-needle), button count and spacing |
+| **Sleeve** | Length (at the wrist / quarter-inch above / above the watch), drape (relaxed natural fold / pressed flat) |
+
+Phrase the attributes in positive form. "Sharp 90° corners" not "not rounded". "Single button at the wrist edge" not "no double cuff". The rule from the Core Prompting Principle applies: every concept named under negation biases toward that concept.
+
+### Reference Orientation Lock
+
+The fashion instance of scope completeness (editing-guide.md "Reference Block"). Scoping a reference to "construction only" can strip too much — Gemini drops the arm rotation, body angle, or camera direction that came baked into the reference's framing. The fix is to scope the reference to multiple positive attributes: construction AND orientation. Example for a back-of-wrist cuff shot:
+
+```
+Image 2 — Cuff construction and orientation reference. Silently inventory:
+- The exact cuff geometry: [enumerated attributes above]
+- The arm orientation: the model's torso is rotated so the back of the arm,
+  the back of the wrist, and the back of the hand face the camera. The cuff
+  button visible to camera sits on the outside of the wrist.
+```
+
+Two positively-named contributions from one reference. The directive sentence that follows must echo both: "The cuff construction and the back-of-wrist orientation come from Image 2."
 
 ---
 

--- a/plugins/claude-content/skills/generate-image/references/capability-patterns.md
+++ b/plugins/claude-content/skills/generate-image/references/capability-patterns.md
@@ -174,6 +174,8 @@ Settings: --model nano-banana --thinking high --resolution 2K --batch 3 --aspect
 Expected yield: 2/4 keepers (detail crops are simpler than full-body)
 ```
 
+*(Adapt directory names to your campaign layout — `final/` and `raw/` above are MaisonX conventions.)*
+
 Which reference is the bundle-source is a per-campaign choice, not a fixed rule — here it was the hero front shot. This two-input form outperformed the original six-reference setup for detail shots because there were fewer competing signals. Anchor the detail shot to the bundle-source with a continuity assertion (editing-guide.md) and lock the construction with geometry enumeration (below).
 
 ### Geometry Lock for Detail Shots

--- a/plugins/claude-content/skills/generate-image/references/editing-guide.md
+++ b/plugins/claude-content/skills/generate-image/references/editing-guide.md
@@ -129,7 +129,7 @@ When to use:
 - Nano Banana + `--thinking high` only (Pro has a fixed reasoning budget; no benefit)
 - Skip for single-reference edits (overkill) and t2i (irrelevant)
 
-Pattern:
+Prompt template (paste verbatim into your prompt):
 
 ```
 ## Reference inventory — analyze silently before generation

--- a/plugins/claude-content/skills/generate-image/references/editing-guide.md
+++ b/plugins/claude-content/skills/generate-image/references/editing-guide.md
@@ -44,6 +44,20 @@ Image 3: [reference role/description]
 
 Roles stay short — one phrase. Don't enumerate what the reference image contains in the label ("Image 2: Reference outfit — white linen blouse and camel trousers"). That re-describes what the pixels already show; the redundancy creates competing signals against the reference.
 
+**Scope references positively, never via exclusion.** Phrases like "ignore the person, pose, face, and background" or "the model in this image is not retained" name the very elements you want the model to disregard, pulling them back into attention. Instead, list only what to *use* from each reference. The model treats anything you don't name as ambient context for the named contribution — no suppression required.
+
+```
+Bad:    "Image 2: Reference for outfit. Ignore the person, pose, face, and background."
+Good:   "Image 2: Use only for the shirt — collar, button placket, chest pocket, fabric weave."
+
+Bad:    "Image 5: Collar reference. The face visible at the top is NOT the character."
+Good:   "Image 5: Use only for the collar construction — point shape, spread angle, stand height."
+```
+
+The rule: list what to use; never list what to disregard. If a reference contains a contaminant (a face, a hat, a backdrop) the user doesn't want in the output, the way to suppress it is to specify the positive replacement elsewhere ("the identity comes from Image 1") and let the named-use scoping carry the rest.
+
+**Scope to *all* the positive attributes you want — narrow scoping strips co-baked ones.** Scoping a reference to a single attribute ("use only for the silhouette") can drop other attributes baked into that reference's framing: the camera angle, the orientation, the lighting direction it happened to be shot at. If you need those too, name them — "use Image 2 for the silhouette and the 3/4 front camera angle". Two positive contributions from one reference, both explicit. See capability-patterns.md "Reference Orientation Lock" for a worked instance.
+
 ### Minimal Directive Pattern
 
 The whole pattern:
@@ -51,10 +65,10 @@ The whole pattern:
 ```
 [Reference block]
 
-Replace [scope] with [pointer to reference]. Do not change anything else.
+Replace [scope] with [pointer to reference].
 ```
 
-One directive that points to the change. One stop clause that protects everything else.
+One directive that points to the change. The verb's implicit scope carries the preservation work — `Replace` edits in place by definition, so everything else stays. No stop clause needed.
 
 Example:
 
@@ -62,12 +76,14 @@ Example:
 Image 1: Base photograph to edit
 Image 2: Character and wardrobe reference
 
-Replace the person in Image 1 with the woman from Image 2, wearing her exact outfit from Image 2. Do not change anything else.
+Replace the person in Image 1 with the woman from Image 2, wearing her exact outfit from Image 2.
 ```
 
-The directive's job is to **connect the dots** between images — name what's being swapped, point to where the replacement comes from. "Do not change anything else" carries the preservation work for everything not explicitly named. Add clauses beyond this only when the model is observably dropping a specific element you need to keep; in that case name only that single element, then stop.
+The directive's job is to **connect the dots** between images — name what's being swapped, point to where the replacement comes from. Add clauses beyond this only when the model is observably dropping a specific element you need to keep; in that case name only that single element in positive form ("Keep the seamless gray backdrop intact"), then stop.
 
 **Why minimal beats verbose.** Every adjective, color word, or preservation enumeration is a degree of freedom the model reconciles against the reference image pixels. Text-vs-image conflicts get resolved by blending both signals — the result matches neither. Over-specifying what the reference already shows actively degrades fidelity. Add detail only when the model cannot infer it from the references and you have a specific outcome in mind for it.
+
+**No "do not change anything else" stop clause.** Earlier versions of this skill used `Do not change anything else.` as the keystone of the minimal directive. Production evidence showed that clause activates the *concept* of changing other things — same negation-biases-toward-the-concept mechanism the Core Prompting Principle warns about. The verb's implicit scope is sufficient; the stop clause is gratuitous and counterproductive.
 
 **Verb choice.**
 - **Replace** anchors to the base scene (model edits in place). Use this for in-place edits.
@@ -75,7 +91,131 @@ The directive's job is to **connect the dots** between images — name what's be
 
 "Only" after the verb tightens scope: "replace only the front figure" beats "replace the front figure." Sentence order affects spatial placement — the element mentioned last in a spatial assignment tends to land in the more prominent position.
 
----
+### Per-Reference Role Assignment
+
+For prompts with three or more references, a single positively-framed directive sentence outperforms a bulleted role list. The pattern: one sentence that assigns each reference its specific contribution, enumerating attributes positively, using replication verbs.
+
+Canonical template:
+
+```
+Perfectly replicate the exact [element] from Image [N]; the exact [element]
+from Image [M]; the [element] from Images [P and Q]; and the [environment,
+lighting, and finish] from Image [S].
+```
+
+Worked example (scene composite):
+
+```
+Perfectly replicate the exact building facade and signage from Image 2; the
+parked vintage car from Image 3; the storefront awning from Image 4; and the
+dusk sky, street lighting, and color grade from Image 1.
+```
+
+What makes this work, structurally:
+
+- **Per-reference role assignment** — every image gets a positively-named job, no ambiguity about which signal goes where
+- **Enumerated attributes per image** — "facade + signage" not "the building"; name the specific parts, not the whole
+- **Replication verbs** — "perfectly replicate", "exact" — positive intensifiers, zero negation
+- **Single coherent sentence** — one directive carries the whole multi-ref assignment, easier for the model to parse than a bulleted block
+
+When the prompt has 3+ references, default to this form. For a fashion worked example (face + garment construction + fabric + lighting across six references), see capability-patterns.md "Multi-Reference Fashion Directive".
+
+## Inventory Preamble (Nano Banana + thinking high)
+
+For multi-reference composition with Nano Banana at `--thinking high`, prefix each reference's role with a "silently inventory" instruction. This forces Gemini's auto-regressive head to reason about each reference's design-critical details before diffusion activates — lifting adherence to the attributes you've assigned each reference measurably.
+
+When to use:
+- Multi-reference composition with 3+ references
+- Nano Banana + `--thinking high` only (Pro has a fixed reasoning budget; no benefit)
+- Skip for single-reference edits (overkill) and t2i (irrelevant)
+
+Pattern:
+
+```
+## Reference inventory — analyze silently before generation
+
+Image 1 — [Role: the bundle-source for X, Y, Z]. Silently inventory:
+[the specific attributes this reference owns — enumerated positively].
+
+Image 2 — [Role: the source for attribute W]. Silently inventory:
+- [the precise geometry/structure of W — enumerated per attribute]
+- [any co-baked attribute you also want from this reference, e.g. orientation]
+
+[continue per reference]
+```
+
+Follow the inventory block with a single positive directive sentence (Per-Reference Role Assignment, above) and any `CRITICAL` sections needed for geometry lock or continuity. For a worked fashion inventory (a reference scoped to both cuff construction and arm orientation), see capability-patterns.md "Reference Orientation Lock".
+
+## Constraint Locking with CRITICAL Sections
+
+A `## CRITICAL — [attribute]` block is a general constraint-locking primitive, not a fixed menu. Any attribute the model tends to drift on can get its own CRITICAL section that names the target positively and in detail. Geometry and continuity (below) are the two with full worked treatment, but production prompts routinely stack several different locks in one prompt:
+
+| Lock | What it pins | One-line shape |
+|---|---|---|
+| **Identity** | a character's face/hair/skin across shots | "The subject is exactly the person from Image 1 — same hair, jawline, skin tone and grain; identity sourced exclusively from Image 1." |
+| **Skin & finish** | texture realism, no plastic/waxy look | "Natural unedited skin with visible pores and matte complexion. Muted naturalistic neutral palette." |
+| **Lighting & color** | photographic register continuity | "Same key-light direction, shadow density and falloff, color science, and finish as Image 1." |
+| **Geometry** | exact construction / proportions | enumerate per attribute — see Geometry Enumeration |
+| **Orientation / pose** | which way the subject faces | "The back of the head faces the lens; the head turns slightly so a sliver of cheek shows in profile at the frame's right edge." |
+| **Continuity** | a whole bundle from one reference | "from the same set as Image 1: same subject, same setting, same light" — see Continuity Assertion |
+| **Subject-pose adaptation** | drape/fall follows the new pose, not the reference's | "Adapt the garment drape to the described pose, not Image 3's pose. Follow Image 3 only for color, cut, construction." |
+
+**It's a balance.** Each CRITICAL section removes a degree of freedom — raising fidelity on that attribute, but also adding tokens the model must reconcile and risking crowding out others. Lock the attributes that both (a) matter for this shot and (b) the model is actually drifting on. A simple t2i or single-element edit needs none. A complex multi-reference composition — where identity, construction, lighting, and skin realism all have to hold at once — earns several stacked locks. The count scales with how many independent things can drift, not with how ambitious the prompt is. Add a lock when you observe drift; don't pre-emptively lock everything. An attribute the references already carry reliably (because a hero image encodes it) needs no lock — see Single-Reference Collapse.
+
+Two empirical patterns from production:
+
+- **Skin & finish is the near-universal lock for photorealistic human shots.** Generative skin reliably drifts toward plastic, waxy, or over-retouched, so it earns a lock even when every other attribute is stable. It is often the *only* lock a hero-anchored shot needs.
+- **The harder it is for the references to carry an attribute, the more it needs an explicit lock.** A back view where the face is mostly hidden has almost no pixels to anchor identity, so identity must be re-asserted in text even though a hero portrait exists. When a reference *can't* be used for a lock (e.g. a construction reference that leaks an unwanted face), describe the attribute in text instead and annotate the header — `## CRITICAL — Collar geometry (described, not image-referenced)`.
+
+Place CRITICAL sections after the generation directive and shot description, one per attribute, each headed `## CRITICAL — [attribute]`. Phrase every lock positively (the rule from the Core Prompting Principle in SKILL.md).
+
+## Continuity Assertion (Composition Lock)
+
+When an output should inherit a *bundle* of qualities from one reference — an identity, OR a product, OR an environment plus its light, grade, and finish — assert sameness in a single clause instead of enumerating each quality. The bundle-source can be any reference; name the attributes that reference owns.
+
+```
+This is a [shot] from the same [session / set / scene] as Image [N]:
+same [subject], same [setting], same [light].
+```
+
+The phrase does enormous load-bearing work — production runs replaced multi-paragraph preservation blocks with this single sentence and got tighter coherence. Use it as a dedicated `## CRITICAL — Continuity` section in any follow-up shot that should read as part of the same set as an earlier image.
+
+Generic example — compositing a product onto a recurring set:
+
+```
+## CRITICAL — Continuity
+
+This is a detail shot from the same set as Image 1: same product, same marble
+table, same softbox lighting, same color grade. The bottle is the visual hero,
+centered in the frame against the table surface.
+```
+
+This works because asserting continuity ("same set as Image 1") re-anchors the whole bundle in one token-cheap clause, where re-describing each quality separately would multiply the degrees of freedom the model has to reconcile against the reference. For a fashion worked example (back-of-wrist detail anchored to a hero shoot), see capability-patterns.md "Detail Shots".
+
+## Single-Reference Collapse
+
+Once one image reliably encodes a locked bundle of attributes — because an earlier generation produced it, or because it was assembled for the purpose — drop the references that originally contributed those attributes. A composite built from six references to establish a subject can collapse to two inputs for follow-ups: the locked image as the bundle-source, plus the single reference for the new attribute being introduced.
+
+Fewer references means fewer competing signals, which raises fidelity on the attributes that matter. The collapse is not domain-specific:
+
+- **Character work** — once a hero portrait locks the face, drop the turnaround/character sheets; use the portrait plus the new pose or wardrobe reference.
+- **Product work** — once a hero render locks materials and lighting, drop the CAD/lighting refs; use the render plus the new angle reference.
+- **Scene work** — once an establishing frame locks the environment and grade, drop the mood-board refs; use the frame plus the new foreground element.
+
+Which reference becomes the bundle-source is a per-task choice, not a fixed rule. For the fashion instance (a hero front shot collapses the character sheet and lighting reference for every follow-up detail crop), see capability-patterns.md "Detail Shots".
+
+## Geometry Enumeration
+
+A generic "match Image 2 exactly" does not preserve specific geometric attributes — the model reads "exactly" aspirationally and lets dimensions, edge shapes, counts, and angles drift seed-to-seed. To lock geometry, enumerate each attribute explicitly and positively in a dedicated `## CRITICAL — Geometry match` section.
+
+This applies to any object with specific geometry the reference cannot be trusted to carry on its own:
+
+- **A logo** — stroke weight, corner radius, letter-spacing, x-height, overall aspect ratio
+- **An architectural feature** — window proportions, column count, roof pitch, bay spacing
+- **A product silhouette** — neck-to-body ratio, shoulder curve, base diameter
+- **A face** — feature spacing, jaw angle, brow position
+
+Phrase every attribute positively — "sharp 90° corners" not "not rounded", "a single fastener at the edge" not "no double row". For the fashion garment-region instance (cuff / collar / placket / sleeve attribute table), see capability-patterns.md "Geometry Lock for Detail Shots".
 
 ## Image Ordering & Numbering
 
@@ -112,10 +252,10 @@ No manual masking needed. Language creates the edit boundary — name the elemen
 
 ```
 "Using the provided image of a living room, change only the blue sofa
-to a vintage brown leather chesterfield. Do not change anything else."
+to a vintage brown leather chesterfield."
 ```
 
-"Only" defines scope. The element name ("the blue sofa") defines the mask region. "Do not change anything else" protects everything else.
+"Only" after the verb defines scope. The element name ("the blue sofa") defines the mask region. The `change` verb's implicit scope protects everything else — no stop clause needed.
 
 ---
 
@@ -143,7 +283,7 @@ Always edit on a base image that already has the target angle, framing, and comp
 
 ### Multi-Pass Editing
 
-The minimal directive pattern (one Replace + "Do not change anything else.") works for a single change. When a prompt has two competing changes — garment swap plus sign text, outfit plus accessories, subject plus background — the model compromises on one.
+The minimal directive pattern (one Replace, no stop clause — see "Minimal Directive Pattern" above) works for a single change. When a prompt has two competing changes — garment swap plus sign text, outfit plus accessories, subject plus background — the model compromises on one.
 
 Split into sequential passes: one change per generation call. Pattern for element replacement with correct proportions:
 
@@ -160,3 +300,44 @@ When choosing a base image for garment editing:
 - Prefer images with minimal distinctive accessories
 - Avoid bases where the model wears items (bags, hats, jewelry) you don't want in the output
 - If using outfit references from studio shoots, verify the output preserves the base scene's environment
+
+### Pose to Make Unwanted Elements Impossible
+
+When framing or composition language alone fails to suppress an unwanted element (positive crop instructions get interpreted aspirationally — "tight crop to forearm" still includes the belt), pose the subject so the unwanted element is physically not in the shot. The model gets a concrete physical solution instead of a suppression task.
+
+Worked example: a cuff macro that kept including the trouser. The fix was not "no trouser in frame" — it was repositioning the arm:
+
+```
+Bad:   "Crop tightly to the forearm and cuff only. No belt, no trouser visible."
+Good:  "The arm is held slightly away from the body so the cuff is silhouetted
+        against the studio backdrop. The forearm and hand fill the frame against
+        the seamless backdrop behind them."
+```
+
+The trouser is suppressed not by naming its absence but by giving the arm a physical position where the trouser cannot be visible. Same technique works for accessories ("the hands hang at the sides, fingers loose" makes hand-in-pocket impossible), facial features ("the head is turned profile to camera" makes both eyes impossible to show), and backdrops.
+
+### Asymmetric Directive Collapse
+
+Gemini's editorial training prior couples contrapposto with symmetric framing — "one hand in pocket, the other at side" gets symmetrized to "both hands in pockets" on ~50% of seeds. Standard hedging language ("naturally asymmetric") doesn't help; the model defaults to its prior.
+
+To improve compliance, name the asymmetry as the explicit goal and describe both sides positively in separate clauses:
+
+```
+Bad:   "Hands settle naturally — one in pocket, one at the side."
+Good:  "Only the left hand is in the pocket. The right hand rests visibly at the
+        right thigh with fingers loose. The arms are deliberately asymmetric."
+```
+
+Naming both sides removes the option of guessing; describing the asymmetry as the goal removes the option of regression toward symmetry.
+
+### Listed Alternatives Collapse
+
+When a prompt offers the model multiple options for the same attribute ("hands at sides, OR hand in pocket, OR adjusting cuff"), Gemini picks one option and repeats it across every seed in the batch — defeating the purpose of offering alternatives for variety.
+
+For pose or styling variety across a batch, run separate generations each with a single distinct directive. One prompt = one option; the batch flag controls per-prompt variance, not directive variance.
+
+### Per-Seed Variance
+
+Image generation is stochastic — the same prompt with the same references produces meaningfully different outputs across seeds. For directives requiring precise execution (specific pose, asymmetric framing, exact crop, geometry lock), expect ~50% per-seed hit rate even with locked recipes. The remedy is `--batch 3` or `--batch 4` plus cherry-picking the obeying frame, not iterating prompt language to push consistency past ~75%.
+
+When cherry-picking, judge against the *primary transferred attribute* first — whatever the shot exists to deliver — then secondary consistency (identity, environment), then staging (composition, framing). Decide what is primary per task before you generate; for a multi-reference detail shot the primary attribute is usually the construction being highlighted, not the identity carrying it.


### PR DESCRIPTION
## Summary

The `generate-image` reference docs had over-fit reusable mechanisms to the MaisonX fashion campaign that produced them — hardcoded `<colorway>` paths and an assumption that "the master reference encodes identity" baked one setup into what should be a general guide. This extracts the principles so they apply to any multi-reference work, and adds the constraint-locking concept the production prompts actually use.

- **Architectural split:** `editing-guide.md` is now the domain-neutral grammar; `capability-patterns.md` Fashion section holds the worked fashion instances, each pointing back to its principle (single authoritative home per rule).
- **Named, generalized mechanisms** (each with a non-fashion example; bundle-source is now "any reference," not "the master"):
  - `Multi-Reference Directive Template` → **Per-Reference Role Assignment**
  - `Composition Lock` → **Continuity Assertion**
  - new **Single-Reference Collapse** (Character / Product / Scene)
  - new **Geometry Enumeration** (logo / architecture / product silhouette / face)
- **New parent section "Constraint Locking with CRITICAL Sections":** documents `## CRITICAL —` as a general primitive (identity, skin & finish, lighting/color, geometry, orientation, pose-adaptation, continuity) with the balance principle — lock count scales with how many independent attributes can drift, not prompt ambition. Geometry Enumeration and Continuity Assertion become its two worked instances.
- **Empirical patterns encoded** from the six canonical `final/Lt Blue/` prompts: skin & finish is the near-universal lock for photorealistic human shots; when a reference can't carry an attribute, an explicit text lock substitutes for it.
- **SKILL.md:** workflow step 5, inline example, and checklist neutralized to match; two new checklist items for constraint locking + skin & finish.

Version auto-bumped: claude-content `0.4.12` → `0.4.13`.

## Test plan

- [ ] Skill triggers normally on image-generation requests (frontmatter description unchanged in routing terms)
- [ ] All cross-references resolve (verified locally via grep — no stale section names)
- [ ] Run a non-fashion multi-reference generation to confirm the neutralized phrasings (continuity assertion, per-reference role assignment, constraint locking) fire as well as the campaign-specific versions did
- [ ] Run the next colorway shot to confirm the CRITICAL lock menu covers the real locks used in production