### PR TITLE
feat: self-pruning memory consolidation and on-demand rule loading

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.53",
+      "version": "0.2.54",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.103",
+      "version": "0.8.104",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.102",
+      "version": "0.8.103",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "claude-coding",
       "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
-      "version": "0.2.54",
+      "version": "0.2.55",
       "source": "./plugins/claude-coding"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.101",
+      "version": "0.8.102",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude/rules/claude-memory-architecture.md
+++ b/.claude/rules/claude-memory-architecture.md
@@ -1,3 +1,7 @@
+---
+paths:
+  - "plugins/claude-memory/**"
+---
 # claude-memory Architecture
 
 ## Hook Lifecycle

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.53](https://img.shields.io/badge/v0.2.53-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.54](https://img.shields.io/badge/v0.2.54-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and five agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.103](https://img.shields.io/badge/v0.8.103-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.104](https://img.shields.io/badge/v0.8.104-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.102](https://img.shields.io/badge/v0.8.102-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.103](https://img.shields.io/badge/v0.8.103-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.101](https://img.shields.io/badge/v0.8.101-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.102](https://img.shields.io/badge/v0.8.102-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew install bird            # X / Twitter
 
 <a id="claude-coding"></a>
 
-### 💻 claude-coding &nbsp; ![v0.2.54](https://img.shields.io/badge/v0.2.54-blue?style=flat-square)
+### 💻 claude-coding &nbsp; ![v0.2.55](https://img.shields.io/badge/v0.2.55-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and five agents covering the commit loop, project maintenance, documentation, and code quality.
 

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.54",
+  "version": "0.2.55",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/.claude-plugin/plugin.json
+++ b/plugins/claude-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-coding",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "description": "Coding workflow skills: intelligent commits, push & PR, branch cleanup, CLAUDE.md maintenance, README generation, changelog creation, README updating, and GitHub Actions setup",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.53](https://img.shields.io/badge/v0.2.53-blue?style=flat-square)
+# claude-coding ![v0.2.54](https://img.shields.io/badge/v0.2.54-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and five agents covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/README.md
+++ b/plugins/claude-coding/README.md
@@ -1,4 +1,4 @@
-# claude-coding ![v0.2.54](https://img.shields.io/badge/v0.2.54-blue?style=flat-square)
+# claude-coding ![v0.2.55](https://img.shields.io/badge/v0.2.55-blue?style=flat-square)
 
 Coding workflow skills for Claude Code. Nine skills and five agents covering the commit loop, project maintenance, documentation, and CI setup: stage and commit with conventional format, push and open a PR with smart branch handling, safely prune merged or stale branches, keep your CLAUDE.md accurate and concise, generate professional READMEs through a structured interview, create or update a changelog from git history, refresh an existing README against current codebase state, and configure production-ready Claude Code GitHub Actions workflows.
 

--- a/plugins/claude-coding/skills/update-claudemd/SKILL.md
+++ b/plugins/claude-coding/skills/update-claudemd/SKILL.md
@@ -192,7 +192,7 @@ Execute in this order so topic-file pointers resolve:
 2. Create `.claude/rules/` with `mkdir -p` if missing
 3. Apply topic file actions in this sub-order:
    - Delete orphaned topic files the user approved for removal
-   - Write new topic files; each must carry `paths:` YAML frontmatter scoped to the globs its subject covers (e.g. `paths: ["plugins/*/hooks/**"]`)
+   - Write new topic files; each must carry `paths:` YAML frontmatter scoped to the globs its subject covers, as a block sequence (the full example below shows the shape)
    - Edit existing topic files (applying keep/update/delete/promoted-out/moved-in actions); promoted-out sections are removed here and reappear in CLAUDE.md in step 4
    - Backfill `paths:` frontmatter onto any existing topic file Agent A reported as missing it — without it the file auto-loads every session and defeats progressive disclosure
 4. Write CLAUDE.md with a regenerated `## Topic Files` section at the end, excluding pointers to deleted topic files. Promoted-in sections from step 3 are written as new H2 sections in the CLAUDE.md body (not inside the `## Topic Files` index block)

--- a/plugins/claude-coding/skills/update-claudemd/SKILL.md
+++ b/plugins/claude-coding/skills/update-claudemd/SKILL.md
@@ -17,7 +17,7 @@ allowed-tools:
 
 # Update and Optimize CLAUDE.md
 
-Reconcile project CLAUDE.md and its topic files against codebase reality and git history since each file's last commit. Enforce progressive disclosure: CLAUDE.md is a top-level index of project identity, universal invariants, and pointers to topic files at `.claude/rules/*.md`.
+Reconcile project CLAUDE.md and its topic files against codebase reality and git history since each file's last commit. Enforce progressive disclosure: CLAUDE.md is a top-level index of project identity, universal invariants, and pointers to topic files at `.claude/rules/*.md`. Files in `.claude/rules/` auto-load at SessionStart unless scoped with `paths:` frontmatter — every topic file this skill writes must carry that frontmatter so it loads only when its subsystem's files are touched, not on every session.
 
 Reconciliation scope includes every file in `.claude/rules/`. Topic files are first-class content — they share the same staleness, accuracy, and duplication risks as CLAUDE.md itself and must be audited, reconciled, and (when warranted) edited during every run. They are not appendices.
 
@@ -94,7 +94,7 @@ Also scan for index drift between CLAUDE.md and the topic files directory:
 - `dangling_references` — topic files pointed at from CLAUDE.md's `## Topic Files` section but missing from disk
 - `unreferenced_topic_files` — topic files on disk with no pointer from CLAUDE.md
 
-Return: `sections[{source, name, line_count, classification_hint, promote_back_candidate}]`, `stale_items[{source, item, reason}]`, `duplications[{items, locations}]`, `existing_topic_files[{path, line_count, last_touched, subject, section_count}]`, `dangling_references[]`, `unreferenced_topic_files[]`.
+Return: `sections[{source, name, line_count, classification_hint, promote_back_candidate}]`, `stale_items[{source, item, reason}]`, `duplications[{items, locations}]`, `existing_topic_files[{path, line_count, last_touched, subject, section_count, has_paths_frontmatter}]`, `dangling_references[]`, `unreferenced_topic_files[]`.
 
 **Agent B — Git History Per File** (`subagent_type: Explore`)
 
@@ -126,6 +126,7 @@ Assign exactly one action to every section from Agent A (CLAUDE.md sections AND 
 - `promote → CLAUDE.md` — topic-file content that has become a universal invariant moves back to CLAUDE.md. Reserved for sections Agent A flagged as `promote_back_candidate` — content whose load trigger now applies to almost every task, not just one subsystem. This is the reverse of `demote` and must be used sparingly; the CLAUDE.md budget is tight
 - `move → <other-topic-file>` — topic-file content whose subject clustering changed and now belongs in a different topic file
 - `add` — new content surfaced by research that belongs in CLAUDE.md or a topic file
+- `add-paths-frontmatter → <glob>` — existing topic file lacks `paths:` frontmatter; prepend it scoped to the file's subject. Applied to every file Agent A reported with `has_paths_frontmatter: false`
 
 Address dangling-reference items from Agent A as reconciliation actions:
 - `dangling_references` — either create the missing topic file (if the referenced subject is still valid) or remove the dead pointer from CLAUDE.md
@@ -170,6 +171,7 @@ For each topic file being created:
 For each topic file being updated:
 - Path, line count: `<current> → <estimated>`
 - Keep / update / delete / promoted out / moved in — same structured breakdown as CLAUDE.md
+- Paths frontmatter: added (when `paths:` is being prepended to a file that lacked it)
 - Budget flag if over ~300 lines
 
 For each topic file being left alone: path and one-line reason (no drift detected).
@@ -188,7 +190,11 @@ Execute in this order so topic-file pointers resolve:
 
 1. Run `cp CLAUDE.md CLAUDE.md.bak` via Bash to create a backup before any writes
 2. Create `.claude/rules/` with `mkdir -p` if missing
-3. Apply topic file actions in this sub-order: delete orphaned topic files the user approved for removal, then write new topic files, then edit existing topic files (applying keep/update/delete/promoted-out/moved-in actions). Promoted-out sections are removed from the topic file in this step; they reappear in CLAUDE.md in step 4
+3. Apply topic file actions in this sub-order:
+   - Delete orphaned topic files the user approved for removal
+   - Write new topic files; each must carry `paths:` YAML frontmatter scoped to the globs its subject covers (e.g. `paths: ["plugins/*/hooks/**"]`)
+   - Edit existing topic files (applying keep/update/delete/promoted-out/moved-in actions); promoted-out sections are removed here and reappear in CLAUDE.md in step 4
+   - Backfill `paths:` frontmatter onto any existing topic file Agent A reported as missing it — without it the file auto-loads every session and defeats progressive disclosure
 4. Write CLAUDE.md with a regenerated `## Topic Files` section at the end, excluding pointers to deleted topic files. Promoted-in sections from step 3 are written as new H2 sections in the CLAUDE.md body (not inside the `## Topic Files` index block)
 
 The `## Topic Files` section is regenerated from actual disk state after step 2, not maintained manually. Each entry is a load trigger, not a descriptive link:
@@ -202,7 +208,17 @@ Read on demand — do not load preemptively.
 - `.claude/rules/hooks.md` — before editing anything in plugins/*/hooks/
 ```
 
-The load-trigger phrase is generated from the topic file's subject, not copied from a heading.
+The load-trigger phrase is generated from the topic file's subject, not copied from a heading. The same trigger drives the topic file's own `paths:` frontmatter — the glob and the pointer phrase must agree:
+
+```
+---
+paths:
+  - "plugins/*/hooks/**"
+---
+# Hooks
+```
+
+A topic file with no `paths:` frontmatter loads at every SessionStart with CLAUDE.md priority — the opposite of on-demand. Path-scoping is mandatory.
 
 Use `Edit` for targeted changes when most of CLAUDE.md is staying. Use `Write` only if more than 60% of the file is changing — at that point the document is being regenerated rather than updated.
 

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.102",
+  "version": "0.8.103",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.101",
+  "version": "0.8.102",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.103",
+  "version": "0.8.104",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.103](https://img.shields.io/badge/v0.8.103-blue?style=flat-square)
+# claude-memory ![v0.8.104](https://img.shields.io/badge/v0.8.104-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.101](https://img.shields.io/badge/v0.8.101-blue?style=flat-square)
+# claude-memory ![v0.8.102](https://img.shields.io/badge/v0.8.102-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.102](https://img.shields.io/badge/v0.8.102-blue?style=flat-square)
+# claude-memory ![v0.8.103](https://img.shields.io/badge/v0.8.103-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/agents/memory-auditor.md
+++ b/plugins/claude-memory/agents/memory-auditor.md
@@ -51,9 +51,12 @@ entry: date, memory set scanned, finding counts (STALE/CONTRADICT/MERGE/DATE_FIX
    morning". These decay into meaninglessness. Flag each for conversion to an absolute date.
 
 5. Identify merge opportunities — memory entries that cover overlapping ground and could be
-   combined into a single, stronger entry. Merge criteria: both entries must currently exist,
-   reference the same entity or decision, overlap in content by more than 50%, and a single
-   merged entry must be strictly shorter than the two originals combined.
+   combined into a single, stronger entry. Merge criteria (ANY one triggers a candidate):
+   content overlaps more than 50%; OR the files share a slug prefix and the same subject
+   (e.g. `feedback_composite_*` all covering face-composite — a topic family is the strongest
+   merge signal, check these first); OR both reference the same entity or decision. Both
+   entries must currently exist, and the merged entry must be strictly shorter than the
+   originals combined.
 
 6. Value-based retirement — apply to ALL entries, including principles and preferences. Flag:
    - SUPERSEDED: a newer entry covers the same ground more completely → REMOVE the older.
@@ -91,6 +94,9 @@ names — all current").
   that cover different aspects of the same topic.
 - When a memory entry is partially stale (some claims still true, others outdated), suggest
   an EDIT with the corrected version, not a REMOVE.
+- Any index or cluster pointer you propose (in a Replacement) is a load trigger, not a label:
+  `**When <condition>:** <takeaway>. → [file]` for triggered knowledge, or a terse fact for
+  always-on entries. A pointer that only names a file gets ignored.
 
 ## Edge Cases
 

--- a/plugins/claude-memory/agents/memory-auditor.md
+++ b/plugins/claude-memory/agents/memory-auditor.md
@@ -3,7 +3,8 @@ name: memory-auditor
 description: >
   Use this agent when you need to verify existing memory entries against codebase ground
   truth — checking for stale paths, outdated versions, contradicted facts, and relative
-  dates needing conversion. Recommended PROACTIVELY after large refactors or version bumps.
+  dates — and to prune the corpus by flagging superseded, redundant, and low-value entries.
+  Recommended PROACTIVELY after large refactors or version bumps, or during consolidation.
 model: inherit
 color: blue
 memory: project
@@ -28,7 +29,7 @@ Update your agent memory as you discover recurring staleness patterns, paths tha
 move, and conventions that have shifted. Record which entries have been previously verified
 and their status, so future runs can focus on new or changed entries. Use `Read` to check
 existing memory before writing, and `Write`/`Edit` to update it. Each run, append a brief
-entry: date, memory set scanned, finding counts (STALE/CONTRADICT/MERGE/DATE_FIX: N each).
+entry: date, memory set scanned, finding counts (STALE/CONTRADICT/MERGE/DATE_FIX/SUPERSEDED/REDUNDANT/LOW-VALUE: N each).
 
 ## Process
 
@@ -54,12 +55,19 @@ entry: date, memory set scanned, finding counts (STALE/CONTRADICT/MERGE/DATE_FIX
    reference the same entity or decision, overlap in content by more than 50%, and a single
    merged entry must be strictly shorter than the two originals combined.
 
+6. Value-based retirement — apply to ALL entries, including principles and preferences. Flag:
+   - SUPERSEDED: a newer entry covers the same ground more completely → REMOVE the older.
+   - REDUNDANT: overlaps a sibling entry and adds no distinct value → REMOVE or MERGE.
+   - LOW-VALUE: too generic, obvious, or narrow to change future behavior → REMOVE.
+   Evidence here is corpus-internal (quote the competing/overlapping entry), not codebase.
+   Downward pressure is the goal: a consolidation that retires nothing is suspect.
+
 ## Output Format
 
 Return a structured list of findings. Each finding has:
 
 ```
-Category: STALE | CONTRADICT | MERGE | DATE_FIX
+Category: STALE | CONTRADICT | MERGE | DATE_FIX | SUPERSEDED | REDUNDANT | LOW-VALUE
 Memory file: <filename>
 Entry: "<quoted text from the memory>"
 Evidence: <what you found — the Glob/Grep/git result that proves the issue>
@@ -73,11 +81,12 @@ names — all current").
 
 ## Quality Rules
 
-- Require codebase evidence for every finding. "This might be outdated" is not a finding.
-  Show the Glob that returned nothing, the Grep that found a different signature, or the
-  git log entry that shows the change.
-- Do not flag memories that describe decisions, preferences, or principles — these don't
-  have codebase referents to verify. Focus on entries that name concrete, checkable entities.
+- Require codebase evidence for factual findings (STALE / CONTRADICT / DATE_FIX). "This might
+  be outdated" is not a finding. Show the Glob that returned nothing, the Grep that found a
+  different signature, or the git log entry that shows the change.
+- Principles and preferences have no codebase referent — never flag them STALE or CONTRADICT.
+  But DO evaluate them for SUPERSEDED / REDUNDANT / LOW-VALUE retirement, with corpus-internal
+  evidence. Factual contradiction is not the only removal trigger.
 - For MERGE candidates, both entries must exist and overlap. Don't suggest merging entries
   that cover different aspects of the same topic.
 - When a memory entry is partially stale (some claims still true, others outdated), suggest

--- a/plugins/claude-memory/agents/signal-discoverer.md
+++ b/plugins/claude-memory/agents/signal-discoverer.md
@@ -94,6 +94,9 @@ patterns already captured in existing memories").
   Only surface project-specific or user-specific knowledge.
 - When in doubt about whether something is NOISE or FILL_GAP, ask: "Would knowing this
   change how Claude behaves in a future session?" If no, it's noise.
+- Raise the bar as the corpus matures. A healthy memory set yields few or zero new candidates
+  — returning 0 is a valid, valuable result, not a failure. Do the dedup and ranking yourself;
+  never pad the list or hand back near-duplicates for the caller to filter.
 
 ## Edge Cases
 

--- a/plugins/claude-memory/agents/signal-discoverer.md
+++ b/plugins/claude-memory/agents/signal-discoverer.md
@@ -97,6 +97,9 @@ patterns already captured in existing memories").
 - Raise the bar as the corpus matures. A healthy memory set yields few or zero new candidates
   — returning 0 is a valid, valuable result, not a failure. Do the dedup and ranking yourself;
   never pad the list or hand back near-duplicates for the caller to filter.
+- Supply each entry's index pointer as a load trigger: `**When <condition>:** <takeaway>.` for
+  triggered knowledge, or a terse fact for always-on knowledge. The condition is what makes a
+  future session open the file; a bare topic name gets ignored.
 
 ## Edge Cases
 

--- a/plugins/claude-memory/skills/extract-learnings/SKILL.md
+++ b/plugins/claude-memory/skills/extract-learnings/SKILL.md
@@ -118,7 +118,7 @@ Apply approved edits in this order, so downward pressure actually lands:
 3. Cluster: apply approved section → `memory/clusters/<section>.md` migrations on the post-removal set.
 4. ADD / EDIT: apply remaining additions and edits, each pointer in the Pointer Format.
 
-Verify before reporting: after REMOVE/MERGE, run `Glob memory/**/*.md` and confirm each retired file is gone. Never mark a REMOVE/MERGE row "done" unless the file is verified absent — claiming a deletion that did not happen is the exact failure this guards against.
+Verify before reporting: after REMOVE/MERGE, run `Glob memory/**/*.md` from resolved path and confirm each retired file is gone. Never mark a REMOVE/MERGE row "done" unless the file is verified absent — claiming a deletion that did not happen is the exact failure this guards against.
 
 Output summary table:
 
@@ -127,7 +127,7 @@ Output summary table:
 |----------|--------|--------|--------|
 ```
 
-Only if Phase 2 agents ran (not an early-exit capture): write the consolidation marker (required — a skipped marker re-fires the nudge next session):
+Only if Phase 2 agents ran (not an early-exit capture): write the consolidation marker (required — a skipped marker re-fires the nudge next session). Use Bash, not Write — Write requires a prior Read and cannot create a new file:
 `Bash: date -u +%Y-%m-%dT%H:%M:%SZ > <memory-dir>/.last-consolidation`
 
 Phase 4 is complete when all approved edits are applied, every REMOVE/MERGE is verified absent via Glob, the marker is written, and the summary table is presented.

--- a/plugins/claude-memory/skills/extract-learnings/SKILL.md
+++ b/plugins/claude-memory/skills/extract-learnings/SKILL.md
@@ -14,6 +14,7 @@ allowed-tools:
   - Bash(git:*)
   - Bash(find:*)
   - Bash(date:*)
+  - Bash(trash:*)
   - AskUserQuestion
   - Agent
 ---
@@ -41,6 +42,15 @@ Weave these into conversation at natural moments — after results land, when co
 Placement decision: project-independent preference → L0, project-specific technical → L1, concise working note → L2, detailed reference → L3, repeatable pattern → Meta.
 
 Adaptive clustering: keep MEMORY.md flat until a section exceeds 25 entries; then move that section's pointers into `memory/clusters/<section>.md` and replace the section in MEMORY.md with a single pointer to it. Only MEMORY.md loads every session, so this caps startup cost while detail stays on-demand.
+
+## Pointer Format
+
+Every MEMORY.md and cluster entry is a load trigger, not a label — a future session must recognize its current task in the pointer and open the file. A pointer that only names a file gets ignored, so the index loads without ever being used. Two shapes:
+
+- Triggered (default): `**When <task-condition>:** <one-line takeaway>. → [detail](file.md)`. Use whenever a sharp "when" can be written — e.g. `**When compositing a face onto a turned head:** align centers, tight ellipse. → [detail](feedback_composite_align_tight_ellipse.md)`.
+- Always-on: `<terse fact>. → [detail](file.md)`. Only for rules that apply in every relevant session (locked context, global preferences), where a condition would be fake.
+
+Choose triggered if you can name the task that should open the file; choose always-on only when the rule applies regardless of task. Cluster files carry a short always-on block at the top, then a trigger-index — every other entry is a condition pointer. Do not inline full rule bodies in a cluster; it routes to topic files, detail lives in them.
 
 ## Early Exit Guard
 
@@ -85,7 +95,7 @@ Phase 2 is complete when both agents return reports. If either returns empty or 
 1. Receive agent reports
 2. Deduplicate across reports and against existing memories
 3. Rank by impact, limit ADDs to 3-7 candidates; retirements and merges from the auditor are separate and not capped
-4. For each candidate: determine target layer, target section, action (ADD / EDIT / MERGE / REMOVE)
+4. For each candidate: determine target layer, target section, action (ADD / EDIT / MERGE / REMOVE); write every index/cluster pointer in the Pointer Format (condition-first)
 5. Read target files, check for duplicates
 6. Present proposals:
    ```
@@ -96,23 +106,31 @@ Phase 2 is complete when both agents return reports. If either returns empty or 
    - <old line>
    + <new line>
    ```
-7. Consolidation pressure (every consolidation run): convert the auditor's SUPERSEDED / REDUNDANT / LOW-VALUE / MERGE findings into concrete REMOVE/MERGE proposals — a run that only adds is a failure mode. Then per-section overflow check: if any MEMORY.md section exceeds 25 entries, propose migrating it to `memory/clusters/<section>.md` and replacing the section with a single pointer (adaptive clustering)
+7. Consolidation pressure (every consolidation run), in order: (a) convert the auditor's SUPERSEDED / REDUNDANT / LOW-VALUE / MERGE findings into concrete REMOVE/MERGE proposals — a run that only adds is a failure mode; (b) ONLY after retirements and merges are settled, run the per-section overflow check on the reduced set — if any MEMORY.md section still exceeds 25 entries, propose migrating it to `memory/clusters/<section>.md` and replacing the section with a single pointer (adaptive clustering). Clustering never runs before retirement; it must not mask removable entries. When migrating into or editing an existing cluster, extract any inline rule bodies into topic files so the cluster stays a pure trigger-index (Pointer Format) — this reshapes muddled clusters on the next run that touches them. Early-exit captures (no auditor findings) skip (a) and run (b) only if the new entry pushes a section past 25
 8. Layer 0 gate — if targeting `~/.claude/CLAUDE.md`, warn: "This modifies global instructions loaded in every session across all projects. Confirm?"
 9. AskUserQuestion: Approve all / Approve selectively / Reject
 
 ### Phase 4: Execute
 
-Apply approved edits. Output summary table:
+Apply approved edits in this order, so downward pressure actually lands:
+1. REMOVE: delete each retired topic file with `Bash: trash <path>` (trash, never rm — reversible), then remove its pointer from MEMORY.md or the cluster file.
+2. MERGE: write the merged entry, then trash the absorbed file(s) and drop their pointers.
+3. Cluster: apply approved section → `memory/clusters/<section>.md` migrations on the post-removal set.
+4. ADD / EDIT: apply remaining additions and edits, each pointer in the Pointer Format.
+
+Verify before reporting: after REMOVE/MERGE, run `Glob memory/**/*.md` and confirm each retired file is gone. Never mark a REMOVE/MERGE row "done" unless the file is verified absent — claiming a deletion that did not happen is the exact failure this guards against.
+
+Output summary table:
 
 ```
 | Learning | Action | Target | Status |
 |----------|--------|--------|--------|
 ```
 
-Only if Phase 2 agents ran (not an early-exit capture): write consolidation marker using Bash (Write tool requires prior Read and cannot create new files):
+Only if Phase 2 agents ran (not an early-exit capture): write the consolidation marker (required — a skipped marker re-fires the nudge next session):
 `Bash: date -u +%Y-%m-%dT%H:%M:%SZ > <memory-dir>/.last-consolidation`
 
-Phase 4 is complete when all approved edits are applied and the summary table is presented.
+Phase 4 is complete when all approved edits are applied, every REMOVE/MERGE is verified absent via Glob, the marker is written, and the summary table is presented.
 
 ## Content Quality Rules
 

--- a/plugins/claude-memory/skills/extract-learnings/SKILL.md
+++ b/plugins/claude-memory/skills/extract-learnings/SKILL.md
@@ -24,7 +24,7 @@ Weave these into conversation at natural moments — after results land, when co
 
 - Most users say "remember this" expecting a single note — this skill actually runs two parallel agents (auditor + discoverer) to both capture new knowledge and verify existing memories haven't gone stale.
 - The 5-layer memory hierarchy means the right knowledge loads at the right time — universal preferences in L0, project architecture in L1, working notes in L2 — without polluting every session with everything.
-- Consolidation ("dream") is the maintenance mode: it prunes outdated memories, promotes patterns that keep recurring, and keeps the memory index under 200 lines so it stays useful.
+- Consolidation ("dream") is the maintenance mode: it prunes outdated and low-value memories, merges overlaps, and clusters overflowing sections so the always-loaded index stays small.
 - For teams: memories captured here carry forward to every future session in this project, making onboarding and context-switching dramatically faster.
 
 ## Memory Hierarchy
@@ -33,11 +33,14 @@ Weave these into conversation at natural moments — after results land, when co
 |-------|------|--------|---------|
 | 0 | `~/.claude/CLAUDE.md` | Every session, all projects | Universal behavioral preferences |
 | 1 | `<repo>/CLAUDE.md` | Every session, this project | Architecture, conventions, gotchas |
-| 2 | `memory/MEMORY.md` (project dir) | Every session, agent-managed | Evolving notes, working knowledge |
+| 2 | `memory/MEMORY.md` (project dir) | Every session, agent-managed | Top index: working notes + pointers to clusters/topics |
+| 2c | `memory/clusters/*.md` sub-index | On-demand (after a section overflows) | Section sub-index split off MEMORY.md to cap always-loaded size |
 | 3 | `memory/*.md` topic files | On-demand | Detailed reference too long for L2 |
 | Meta | Suggest new skill/command | N/A | Repeatable workflow → automation |
 
 Placement decision: project-independent preference → L0, project-specific technical → L1, concise working note → L2, detailed reference → L3, repeatable pattern → Meta.
+
+Adaptive clustering: keep MEMORY.md flat until a section exceeds 25 entries; then move that section's pointers into `memory/clusters/<section>.md` and replace the section in MEMORY.md with a single pointer to it. Only MEMORY.md loads every session, so this caps startup cost while detail stays on-demand.
 
 ## Early Exit Guard
 
@@ -58,7 +61,7 @@ If the user said "remember X" with explicit content already in context — and t
 
 Steps 2-4 are required and run as parallel tool calls.
 
-2. Read MEMORY.md + list topic files (`Glob memory/*.md` from resolved path)
+2. Read MEMORY.md + list topic and cluster files (`Glob memory/**/*.md` from resolved path)
 3. Read both CLAUDE.md files (`~/.claude/CLAUDE.md` + `<repo>/CLAUDE.md`) — required for dedup quality; skipping means proposals may duplicate L0/L1 content
 4. `git log --oneline -20`
 5. Build context snapshot: summarize existing knowledge + list verification targets (file paths, functions, patterns named in memories)
@@ -67,7 +70,7 @@ Steps 2-4 are required and run as parallel tool calls.
 
 Launch both agent calls in a single message so they run in parallel. Use the Agent tool with:
 
-- **Memory Auditor**: `subagent_type: "claude-memory:memory-auditor"`. In the `prompt`, include the context snapshot from Phase 1 — memory file contents, git log output, and verification targets list.
+- **Memory Auditor**: `subagent_type: "claude-memory:memory-auditor"`. In the `prompt`, include the context snapshot from Phase 1 — memory file contents, git log output, and verification targets list. Instruct it to surface retirement and merge candidates (SUPERSEDED / REDUNDANT / LOW-VALUE / MERGE), not only factually stale entries — downward pressure is the point of consolidation.
 
 - **Signal Discoverer**: `subagent_type: "claude-memory:signal-discoverer"`. In the `prompt`, include existing memory summaries (for dedup) and the project name.
 
@@ -81,8 +84,8 @@ Phase 2 is complete when both agents return reports. If either returns empty or 
 
 1. Receive agent reports
 2. Deduplicate across reports and against existing memories
-3. Rank by impact, limit to 3-7 candidates
-4. For each candidate: determine target layer, target section, action (ADD / EDIT / REMOVE)
+3. Rank by impact, limit ADDs to 3-7 candidates; retirements and merges from the auditor are separate and not capped
+4. For each candidate: determine target layer, target section, action (ADD / EDIT / MERGE / REMOVE)
 5. Read target files, check for duplicates
 6. Present proposals:
    ```
@@ -93,7 +96,7 @@ Phase 2 is complete when both agents return reports. If either returns empty or 
    - <old line>
    + <new line>
    ```
-7. MEMORY.md line check — if over 170 lines, propose specific demotions to L3 or removals
+7. Consolidation pressure (every consolidation run): convert the auditor's SUPERSEDED / REDUNDANT / LOW-VALUE / MERGE findings into concrete REMOVE/MERGE proposals — a run that only adds is a failure mode. Then per-section overflow check: if any MEMORY.md section exceeds 25 entries, propose migrating it to `memory/clusters/<section>.md` and replacing the section with a single pointer (adaptive clustering)
 8. Layer 0 gate — if targeting `~/.claude/CLAUDE.md`, warn: "This modifies global instructions loaded in every session across all projects. Confirm?"
 9. AskUserQuestion: Approve all / Approve selectively / Reject
 


### PR DESCRIPTION
## Summary

Two related changes to how this marketplace's tooling manages always-loaded context, unified by one principle: replace unconditional loading with trigger-activated loading.

### Memory consolidation was append-only

`extract-learnings` is meant to manage memory, but nothing applied downward pressure. `signal-discoverer` only adds; `memory-auditor` removed entries only on factual contradiction — explicitly exempting decisions, preferences, and principles, which are the large majority of entries; and the single size gate fired at 170 lines while real indexes sit well below it. The index grew without bound.

- `memory-auditor`: adds value-based retirement — `SUPERSEDED` / `REDUNDANT` / `LOW-VALUE` categories that apply to principles, not just factually-checkable entries. Factual contradiction is no longer the only removal trigger.
- `signal-discoverer`: adds a raise-the-bar rule — zero new candidates is a valid, valuable result, not a failure.
- `extract-learnings`: replaces the dead size gate with per-run downward pressure, plus adaptive clustering — a `MEMORY.md` section past 25 entries splits into `memory/clusters/<section>.md`, capping the always-loaded index while detail stays on demand.

### update-claudemd defeated its own progressive disclosure

The skill writes topic files to `.claude/rules/`, but `.claude/rules/*.md` auto-loads at SessionStart with CLAUDE.md priority unless scoped with `paths:` frontmatter (per [the docs](https://code.claude.com/docs/en/memory)). So every "load on demand" topic file actually loaded every session — the opposite of the skill's stated purpose.

- `update-claudemd`: mandates `paths:` frontmatter on every topic file it writes, scoped to the globs the subject covers, and threads the backfill of existing files through the research → classify → approve pipeline so it surfaces at the approval gate instead of being a silent rewrite.
- `.claude/rules/claude-memory-architecture.md`: applies the fix to this repo's own leaking file (it was loading ~1.5k every session); now scoped to `plugins/claude-memory/**`, so it loads only when that subsystem is touched.

## Commits

- `feat(memory)` — self-pruning consolidation with adaptive clustering
- `fix(coding)` — scope `.claude/rules` topic files with `paths` frontmatter

## Notes

Plugin version bumps and README badge syncs in the diff are from the `auto-version` pre-commit hook, one per affected plugin.
