### PR TITLE
feat(memory): add --summary mode + volume fan-out signal to recall

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.104",
+      "version": "0.8.105",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.105",
+      "version": "0.8.106",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.106",
+      "version": "0.8.107",
       "source": "./plugins/claude-memory"
     },
     {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.104](https://img.shields.io/badge/v0.8.104-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.105](https://img.shields.io/badge/v0.8.105-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.106](https://img.shields.io/badge/v0.8.106-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.107](https://img.shields.io/badge/v0.8.107-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.105](https://img.shields.io/badge/v0.8.105-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.106](https://img.shields.io/badge/v0.8.106-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.106",
+  "version": "0.8.107",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.105",
+  "version": "0.8.106",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.104",
+  "version": "0.8.105",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.104](https://img.shields.io/badge/v0.8.104-blue?style=flat-square)
+# claude-memory ![v0.8.105](https://img.shields.io/badge/v0.8.105-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.106](https://img.shields.io/badge/v0.8.106-blue?style=flat-square)
+# claude-memory ![v0.8.107](https://img.shields.io/badge/v0.8.107-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.105](https://img.shields.io/badge/v0.8.105-blue?style=flat-square)
+# claude-memory ![v0.8.106](https://img.shields.io/badge/v0.8.106-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/skills/recall-conversations/SKILL.md
+++ b/plugins/claude-memory/skills/recall-conversations/SKILL.md
@@ -12,6 +12,7 @@ allowed-tools:
   - Glob
   - Bash(python3:*)
   - AskUserQuestion
+  - Agent
 ---
 
 ## Value Context
@@ -74,6 +75,13 @@ The recipe gets you the data. The lens tells you what to *look for* — for inst
 - Search supplementary terms (per-lens patterns in `references/lenses.md`)
 - Widen scope: append `--all-projects` to look across projects
 - Two rounds of deepening with no new signal → synthesize from what you have rather than thrashing further
+
+### 4. Manage volume on broad queries (high blast radius)
+
+The scripts emit full transcripts, so broad/multi-session lenses can flood context. Defend in two tiers — never trigger on session count alone; continuation-restore and specific-lookup lenses stay in-thread regardless of how many sessions match (the answer is small):
+
+1. `--summary` — append for run-retro, find-gaps, find-antipatterns, extract-decisions, or any `--all-projects`/multi-week scope. Emits precomputed per-session digests instead of full content (~3× smaller, single-pass, free). The scripts flag when to reach for it: a large full-content pull sets `summary_suggested` (JSON meta) or prints an `INFO:` line on stderr. Never use `--summary` for restore-context or specific lookups — they need exact full text.
+2. Fan out — only when even `--summary` output is still too big: `fanout_suggested` is true in JSON meta (or the stderr `INFO:` line recommends fanning out). Spawn one `Agent` per project (`subagent_type: general-purpose`, `model: sonnet`), each running the recipe scoped to its own project and returning a structured digest; then reduce. Shard by project, never by arbitrary session count — count-based splits sever a decision or antipattern thread across agents, and per-project shards preserve cross-session dedup within each mind.
 
 ---
 

--- a/plugins/claude-memory/skills/recall-conversations/references/tool-reference.md
+++ b/plugins/claude-memory/skills/recall-conversations/references/tool-reference.md
@@ -19,6 +19,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/skills/recall-conversations/scripts/recent_chats.p
 | `--before DATE`           | Sessions before this datetime (ISO)                                 |
 | `--after DATE`            | Sessions after this datetime (ISO)                                  |
 | `--verbose`, `-v`         | Include files_modified, commits, tool_counts                        |
+| `--summary`               | Emit precomputed per-session digests instead of full content (~3× smaller, single-pass). Skips the message fetch. |
 | `--format markdown\|json` | Output format (default: markdown)                                   |
 | `--json`                  | Alias for `--format json`                                           |
 | `--include-notifications` | Include task notification messages                                  |
@@ -28,6 +29,8 @@ python3 ${CLAUDE_PLUGIN_ROOT}/skills/recall-conversations/scripts/recent_chats.p
 | `-h, --help`              | Show help with examples                                             |
 
 Use `--verbose` for lenses that need file/commit context (restore-context, review-process, run-retro).
+
+Use `--summary` for broad/multi-session lenses (run-retro, find-gaps, find-antipatterns, extract-decisions) or `--all-projects` scope to keep context small. When retrieved content exceeds the volume budget, markdown mode prints an `INFO: …` signal to stderr and JSON mode adds three keys to `meta`: `content_chars`, `summary_suggested` (large full-content pull — switch to `--summary`), and `fanout_suggested` (large even after `--summary` — escalate to per-project subagent fan-out).
 
 ## search_conversations.py
 
@@ -44,6 +47,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/skills/recall-conversations/scripts/search_convers
 | `--project NAME`          | Filter by project name(s), comma-separated. Default: auto-detected. |
 | `--all-projects`          | Widen scope to all projects (overrides auto-detect)                 |
 | `--verbose`, `-v`         | Include files_modified, commits                                     |
+| `--summary`               | Emit precomputed per-session digests instead of full content (~3× smaller, single-pass). Skips the message fetch. |
 | `--format markdown\|json` | Output format (default: markdown)                                   |
 | `--json`                  | Alias for `--format json`                                           |
 | `--include-notifications` | Include task notification messages                                  |

--- a/plugins/claude-memory/skills/recall-conversations/references/tool-reference.md
+++ b/plugins/claude-memory/skills/recall-conversations/references/tool-reference.md
@@ -32,6 +32,8 @@ Use `--verbose` for lenses that need file/commit context (restore-context, revie
 
 Use `--summary` for broad/multi-session lenses (run-retro, find-gaps, find-antipatterns, extract-decisions) or `--all-projects` scope to keep context small. When retrieved content exceeds the volume budget, markdown mode prints an `INFO: …` signal to stderr and JSON mode adds three keys to `meta`: `content_chars`, `summary_suggested` (large full-content pull — switch to `--summary`), and `fanout_suggested` (large even after `--summary` — escalate to per-project subagent fan-out).
 
+`--summary` composes with `--verbose`: you still get the files-modified / commits / tool-counts metadata header, only the conversation body is replaced by the precomputed summary. In JSON, summary mode reports `total_summaries` instead of `total_messages`.
+
 ## search_conversations.py
 
 Search for sessions containing keywords using full-text search (FTS5/FTS4/LIKE cascade).

--- a/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/cli_common.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/cli_common.py
@@ -34,6 +34,9 @@ def _get_plugin_version() -> str:
 PLUGIN_VERSION = _get_plugin_version()
 LIMIT_MIN = 1
 LIMIT_MAX = 50
+# Retrieved output above this many characters is "large" — the orchestrator should
+# prefer --summary, and if already summarized, fan out by-project subagents.
+FANOUT_SUGGEST_CHARS = 50000
 
 
 def resolve_project(cwd: str, conn: sqlite3.Connection) -> Optional[list[str]]:
@@ -98,6 +101,9 @@ def add_common_args(parser: argparse.ArgumentParser, default_limit: int = 5) -> 
 
     parser.add_argument("--verbose", "-v", action="store_true",
                         help="Include files_modified, commits, tool_counts.")
+    parser.add_argument("--summary", action="store_true",
+                        help="Emit precomputed per-session summaries instead of full message "
+                             "content — token-efficient for broad/retro/multi-session queries.")
     parser.add_argument("--include-notifications", action="store_true",
                         help="Include task notification messages (hidden by default).")
     parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH,
@@ -175,6 +181,50 @@ def emit_warning(message: str, fmt: str) -> None:
         sys.stderr.write(json.dumps({"warning": message}) + "\n")
     else:
         sys.stderr.write(f"WARN: {message}\n")
+
+
+def volume_signal(output_chars: int, summary_mode: bool) -> tuple[bool, str]:
+    """Classify retrieved output volume and return (is_large, escalation_hint).
+
+    Drives the fan-out decision mechanically rather than by guessing from session
+    count: small answers (the common continuation/lookup case) never escalate.
+    """
+    if output_chars <= FANOUT_SUGGEST_CHARS:
+        return False, ""
+    if summary_mode:
+        hint = ("summarized output still exceeds the volume budget — fan out general-purpose "
+                "subagents sharded by project, then reduce")
+    else:
+        hint = ("re-run with --summary for precomputed summaries; if still large, fan out "
+                "general-purpose subagents sharded by project")
+    return True, hint
+
+
+def volume_flags(content_chars: int, summary_mode: bool) -> dict:
+    """Two-tier escalation flags derived from retrieved volume — the single source
+    of truth for both recall scripts' JSON meta.
+
+    summary_suggested: full-content pull is large → switch to --summary (tier 1).
+    fanout_suggested: even --summary output is large → fan out by project (tier 2).
+    The two are mutually exclusive by construction.
+    """
+    is_large = volume_signal(content_chars, summary_mode)[0]
+    return {
+        "content_chars": content_chars,
+        "summary_suggested": is_large and not summary_mode,
+        "fanout_suggested": is_large and summary_mode,
+    }
+
+
+def emit_volume_signal(output_chars: int, session_count: int, summary_mode: bool, fmt: str) -> None:
+    """Write a stderr nudge when retrieved output is large (markdown mode only)."""
+    if fmt == "json":
+        return
+    is_large, hint = volume_signal(output_chars, summary_mode)
+    if is_large:
+        sys.stderr.write(
+            f"INFO: retrieved {output_chars} chars across {session_count} sessions; {hint}.\n"
+        )
 
 
 def open_db_or_exit(db_path: Path, fmt: str) -> sqlite3.Connection:

--- a/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/formatting.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/formatting.py
@@ -117,6 +117,13 @@ def format_markdown_session(session: dict, verbose: bool = False) -> str:
             lines.append("\n### Tools Used")
             lines.append(tools_str)
 
+    if session.get("summary") is not None:
+        lines.append("\n### Summary\n")
+        summ = (session.get("summary") or "").strip()
+        lines.append(summ if summ else "_(summary unavailable — re-run this session without --summary)_")
+        lines.append("\n---\n")
+        return "\n".join(lines)
+
     lines.append("\n### Conversation\n")
 
     for msg in session.get("messages", []):

--- a/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/formatting.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/formatting.py
@@ -139,12 +139,17 @@ def format_markdown_session(session: dict, verbose: bool = False) -> str:
 
 def format_json_sessions(sessions: list[dict], extra: Optional[dict] = None) -> str:
     """Format sessions as JSON with metadata."""
-    total_messages = sum(len(s.get("messages", [])) for s in sessions)
     output = {
         "sessions": sessions,
         "total_sessions": len(sessions),
-        "total_messages": total_messages
     }
+    # Summary-mode sessions carry a "summary" string instead of a "messages" list, so
+    # total_messages would always be 0 and mislead JSON consumers. Report the matching
+    # counter instead.
+    if any("summary" in s for s in sessions):
+        output["total_summaries"] = sum(1 for s in sessions if "summary" in s)
+    else:
+        output["total_messages"] = sum(len(s.get("messages", [])) for s in sessions)
     if extra:
         output.update(extra)
     return json.dumps(output, indent=2)

--- a/plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py
@@ -18,10 +18,12 @@ import sys
 from memory_lib.cli_common import (
     add_common_args,
     emit_error,
+    emit_volume_signal,
     open_db_or_exit,
     resolve_format,
     resolve_scope,
     validate_limit,
+    volume_flags,
 )
 from memory_lib.formatting import format_markdown_session, format_json_sessions
 
@@ -57,8 +59,9 @@ def get_recent_sessions(
     projects: list[str] | None,
     verbose: bool,
     include_notifications: bool,
+    summary: bool = False,
 ) -> list[dict]:
-    """Get recent sessions with their messages."""
+    """Get recent sessions with their messages (or precomputed summaries if summary=True)."""
     cursor = conn.cursor()
 
     cursor.execute("PRAGMA table_info(branches)")
@@ -70,7 +73,7 @@ def get_recent_sessions(
         SELECT s.id, s.uuid, b.started_at, b.ended_at, b.exchange_count,
                b.files_modified, b.commits, s.git_branch,
                p.name as project, p.path as project_path,
-               b.id as branch_db_id{tool_counts_col}
+               b.id as branch_db_id, b.context_summary{tool_counts_col}
         FROM sessions s
         JOIN branches b ON b.session_id = s.id AND b.is_active = 1
         JOIN projects p ON s.project_id = p.id
@@ -101,24 +104,12 @@ def get_recent_sessions(
         if has_tool_counts:
             (_session_id, uuid, started_at, ended_at, _exchange_count,
              files_json, commits_json, git_branch, project, _project_path,
-             branch_db_id, tool_counts_json) = session
+             branch_db_id, context_summary, tool_counts_json) = session
         else:
             (_session_id, uuid, started_at, ended_at, _exchange_count,
              files_json, commits_json, git_branch, project, _project_path,
-             branch_db_id) = session
+             branch_db_id, context_summary) = session
             tool_counts_json = None
-
-        notif_clause = "" if include_notifications else "AND COALESCE(m.is_notification, 0) = 0"
-        cursor.execute(f"""
-            SELECT m.role, m.content, m.timestamp, COALESCE(m.is_notification, 0) as is_notification
-            FROM branch_messages bm
-            JOIN messages m ON bm.message_id = m.id
-            WHERE bm.branch_id = ? {notif_clause}
-            ORDER BY m.timestamp ASC
-        """, (branch_db_id,))
-
-        messages = [{"role": r, "content": c, "timestamp": t, "is_notification": notif}
-                    for r, c, t, notif in cursor.fetchall()]
 
         session_data = {
             "uuid": uuid,
@@ -126,8 +117,23 @@ def get_recent_sessions(
             "started_at": started_at,
             "ended_at": ended_at,
             "git_branch": git_branch,
-            "messages": messages
         }
+
+        if summary:
+            session_data["summary"] = context_summary or ""
+        else:
+            notif_clause = "" if include_notifications else "AND COALESCE(m.is_notification, 0) = 0"
+            cursor.execute(f"""
+                SELECT m.role, m.content, m.timestamp, COALESCE(m.is_notification, 0) as is_notification
+                FROM branch_messages bm
+                JOIN messages m ON bm.message_id = m.id
+                WHERE bm.branch_id = ? {notif_clause}
+                ORDER BY m.timestamp ASC
+            """, (branch_db_id,))
+            session_data["messages"] = [
+                {"role": r, "content": c, "timestamp": t, "is_notification": notif}
+                for r, c, t, notif in cursor.fetchall()
+            ]
 
         if verbose:
             session_data["files_modified"] = json.loads(files_json) if files_json else []
@@ -178,12 +184,19 @@ def main():
             projects=projects,
             verbose=args.verbose,
             include_notifications=args.include_notifications,
+            summary=args.summary,
         )
     except Exception as e:
         emit_error("query_failed", str(e), None, fmt)
         sys.exit(1)
     finally:
         conn.close()
+
+    content_chars = sum(
+        len(s.get("summary") or "")
+        + sum(len(m.get("content") or "") for m in s.get("messages", []))
+        for s in sessions
+    )
 
     if fmt == "json":
         meta = {
@@ -192,10 +205,12 @@ def main():
                 "auto_detected": auto_detected,
             },
             "has_more": len(sessions) == limit,
+            **volume_flags(content_chars, args.summary),
         }
         print(format_json_sessions(sessions, meta))
     else:
         print(format_markdown(sessions, verbose=args.verbose))
+        emit_volume_signal(content_chars, len(sessions), args.summary, fmt)
 
 
 if __name__ == "__main__":

--- a/plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py
@@ -67,13 +67,18 @@ def get_recent_sessions(
     cursor.execute("PRAGMA table_info(branches)")
     branch_columns = {row[1] for row in cursor.fetchall()}
     has_tool_counts = "tool_counts" in branch_columns
+    has_context_summary = "context_summary" in branch_columns
 
+    # Both columns are optional: an unmigrated DB (opened before _migrate_columns
+    # ran via the import/sync path) may lack either. Gate each read on its own probe
+    # so a normal recall never fails with "no such column" on an old database.
+    context_summary_col = ", b.context_summary" if has_context_summary else ""
     tool_counts_col = ", b.tool_counts" if has_tool_counts else ""
     sql = f"""
         SELECT s.id, s.uuid, b.started_at, b.ended_at, b.exchange_count,
                b.files_modified, b.commits, s.git_branch,
                p.name as project, p.path as project_path,
-               b.id as branch_db_id, b.context_summary{tool_counts_col}
+               b.id as branch_db_id{context_summary_col}{tool_counts_col}
         FROM sessions s
         JOIN branches b ON b.session_id = s.id AND b.is_active = 1
         JOIN projects p ON s.project_id = p.id
@@ -101,15 +106,17 @@ def get_recent_sessions(
 
     results = []
     for session in sessions:
-        if has_tool_counts:
-            (_session_id, uuid, started_at, ended_at, _exchange_count,
-             files_json, commits_json, git_branch, project, _project_path,
-             branch_db_id, context_summary, tool_counts_json) = session
-        else:
-            (_session_id, uuid, started_at, ended_at, _exchange_count,
-             files_json, commits_json, git_branch, project, _project_path,
-             branch_db_id, context_summary) = session
-            tool_counts_json = None
+        # Fixed columns first, then the optional columns in SELECT order
+        # (context_summary, then tool_counts) — index-based to handle any combination.
+        (_session_id, uuid, started_at, ended_at, _exchange_count,
+         files_json, commits_json, git_branch, project, _project_path,
+         branch_db_id) = session[:11]
+        col = 11
+        context_summary = None
+        if has_context_summary:
+            context_summary = session[col]
+            col += 1
+        tool_counts_json = session[col] if has_tool_counts else None
 
         session_data = {
             "uuid": uuid,

--- a/plugins/claude-memory/skills/recall-conversations/scripts/search_conversations.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/search_conversations.py
@@ -18,10 +18,12 @@ import sys
 from memory_lib.cli_common import (
     add_common_args,
     emit_error,
+    emit_volume_signal,
     open_db_or_exit,
     resolve_format,
     resolve_scope,
     validate_limit,
+    volume_flags,
 )
 from memory_lib.content import sanitize_fts_term
 from memory_lib.db import detect_fts_support
@@ -52,6 +54,7 @@ def search_sessions(
     projects: list[str] | None,
     verbose: bool,
     include_notifications: bool,
+    summary: bool = False,
 ) -> list[dict]:
     """Search sessions via FTS5/FTS4 (BM25-ranked when available) or LIKE fallback."""
     cursor = conn.cursor()
@@ -71,7 +74,8 @@ def search_sessions(
 
         sql = """
             SELECT s.id, s.uuid, b.started_at, b.ended_at, b.files_modified,
-                   b.commits, s.git_branch, p.name as project, b.id as branch_db_id
+                   b.commits, s.git_branch, p.name as project, b.id as branch_db_id,
+                   b.context_summary
             FROM branches_fts
             JOIN branches b ON branches_fts.rowid = b.id
             JOIN sessions s ON b.session_id = s.id
@@ -96,7 +100,8 @@ def search_sessions(
         like_clauses = " AND ".join("b.aggregated_content LIKE ?" for _ in terms)
         sql = f"""
             SELECT s.id, s.uuid, b.started_at, b.ended_at, b.files_modified,
-                   b.commits, s.git_branch, p.name as project, b.id as branch_db_id
+                   b.commits, s.git_branch, p.name as project, b.id as branch_db_id,
+                   b.context_summary
             FROM branches b
             JOIN sessions s ON b.session_id = s.id
             JOIN projects p ON s.project_id = p.id
@@ -118,19 +123,8 @@ def search_sessions(
 
     results = []
     for session in sessions:
-        _session_id, uuid, started_at, ended_at, files_json, commits_json, git_branch, project, branch_db_id = session
-
-        notif_clause = "" if include_notifications else "AND COALESCE(m.is_notification, 0) = 0"
-        cursor.execute(f"""
-            SELECT m.role, m.content, m.timestamp, COALESCE(m.is_notification, 0) as is_notification
-            FROM branch_messages bm
-            JOIN messages m ON bm.message_id = m.id
-            WHERE bm.branch_id = ? {notif_clause}
-            ORDER BY m.timestamp ASC
-        """, (branch_db_id,))
-
-        messages = [{"role": r, "content": c, "timestamp": t, "is_notification": notif}
-                    for r, c, t, notif in cursor.fetchall()]
+        (_session_id, uuid, started_at, ended_at, files_json, commits_json,
+         git_branch, project, branch_db_id, context_summary) = session
 
         session_data = {
             "uuid": uuid,
@@ -138,8 +132,23 @@ def search_sessions(
             "started_at": started_at,
             "ended_at": ended_at,
             "git_branch": git_branch,
-            "messages": messages
         }
+
+        if summary:
+            session_data["summary"] = context_summary or ""
+        else:
+            notif_clause = "" if include_notifications else "AND COALESCE(m.is_notification, 0) = 0"
+            cursor.execute(f"""
+                SELECT m.role, m.content, m.timestamp, COALESCE(m.is_notification, 0) as is_notification
+                FROM branch_messages bm
+                JOIN messages m ON bm.message_id = m.id
+                WHERE bm.branch_id = ? {notif_clause}
+                ORDER BY m.timestamp ASC
+            """, (branch_db_id,))
+            session_data["messages"] = [
+                {"role": r, "content": c, "timestamp": t, "is_notification": notif}
+                for r, c, t, notif in cursor.fetchall()
+            ]
 
         if verbose:
             session_data["files_modified"] = json.loads(files_json) if files_json else []
@@ -185,12 +194,19 @@ def main():
             projects=projects,
             verbose=args.verbose,
             include_notifications=args.include_notifications,
+            summary=args.summary,
         )
     except Exception as e:
         emit_error("query_failed", str(e), None, fmt)
         sys.exit(1)
     finally:
         conn.close()
+
+    content_chars = sum(
+        len(s.get("summary") or "")
+        + sum(len(m.get("content") or "") for m in s.get("messages", []))
+        for s in sessions
+    )
 
     if fmt == "json":
         meta = {
@@ -200,10 +216,12 @@ def main():
                 "auto_detected": auto_detected,
             },
             "has_more": len(sessions) == limit,
+            **volume_flags(content_chars, args.summary),
         }
         print(format_json_sessions(sessions, meta))
     else:
         print(format_markdown(sessions, args.query, verbose=args.verbose))
+        emit_volume_signal(content_chars, len(sessions), args.summary, fmt)
 
 
 if __name__ == "__main__":

--- a/plugins/claude-memory/skills/recall-conversations/scripts/search_conversations.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/search_conversations.py
@@ -59,6 +59,12 @@ def search_sessions(
     """Search sessions via FTS5/FTS4 (BM25-ranked when available) or LIKE fallback."""
     cursor = conn.cursor()
 
+    # context_summary is optional: an unmigrated DB may lack it. Gate the read so a
+    # normal search never fails with "no such column" on an old database.
+    cursor.execute("PRAGMA table_info(branches)")
+    has_context_summary = "context_summary" in {row[1] for row in cursor.fetchall()}
+    context_summary_col = ", b.context_summary" if has_context_summary else ""
+
     terms = query.split()
     if not terms:
         return []
@@ -72,10 +78,9 @@ def search_sessions(
             return []
         fts_query = " OR ".join(f'"{term}"' for term in sanitized_terms)
 
-        sql = """
+        sql = f"""
             SELECT s.id, s.uuid, b.started_at, b.ended_at, b.files_modified,
-                   b.commits, s.git_branch, p.name as project, b.id as branch_db_id,
-                   b.context_summary
+                   b.commits, s.git_branch, p.name as project, b.id as branch_db_id{context_summary_col}
             FROM branches_fts
             JOIN branches b ON branches_fts.rowid = b.id
             JOIN sessions s ON b.session_id = s.id
@@ -100,8 +105,7 @@ def search_sessions(
         like_clauses = " AND ".join("b.aggregated_content LIKE ?" for _ in terms)
         sql = f"""
             SELECT s.id, s.uuid, b.started_at, b.ended_at, b.files_modified,
-                   b.commits, s.git_branch, p.name as project, b.id as branch_db_id,
-                   b.context_summary
+                   b.commits, s.git_branch, p.name as project, b.id as branch_db_id{context_summary_col}
             FROM branches b
             JOIN sessions s ON b.session_id = s.id
             JOIN projects p ON s.project_id = p.id
@@ -124,7 +128,8 @@ def search_sessions(
     results = []
     for session in sessions:
         (_session_id, uuid, started_at, ended_at, files_json, commits_json,
-         git_branch, project, branch_db_id, context_summary) = session
+         git_branch, project, branch_db_id) = session[:9]
+        context_summary = session[9] if has_context_summary else None
 
         session_data = {
             "uuid": uuid,

--- a/tests/claude-memory/test_context_injection.py
+++ b/tests/claude-memory/test_context_injection.py
@@ -367,7 +367,7 @@ class TestBuildContext:
         assert "Run pytest from the project root." in result
         assert "User:**" in result
         assert "Assistant:**" in result
-        assert "/recall-conversations" in result
+        assert "claude-memory:recall-conversations" in result
 
     def test_multi_session_separator(self):
         sessions = [
@@ -534,4 +534,4 @@ class TestBuildFallbackContext:
             ],
         }
         result = _build_fallback_context(session)
-        assert "/recall-conversations" in result
+        assert "claude-memory:recall-conversations" in result

--- a/tests/claude-memory/test_summary_mode.py
+++ b/tests/claude-memory/test_summary_mode.py
@@ -1,0 +1,422 @@
+"""Tests for the --summary retrieval mode and volume/fan-out signal.
+
+Coverage:
+1. volume_signal — boundary at 50000, mode-dependent hint direction.
+2. format_markdown_session summary branch — renders ### Summary, no ### Conversation;
+   empty/blank summary shows placeholder.
+3. get_recent_sessions(summary=True/False) — via memory_db fixture.
+4. JSON meta flag truth table (is_large × summary_mode → 4 states).
+5. search_sessions(summary=True/False) — LIKE fallback path.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from memory_lib.cli_common import FANOUT_SUGGEST_CHARS, volume_flags, volume_signal
+from memory_lib.formatting import format_markdown_session
+from recent_chats import get_recent_sessions
+from search_conversations import search_sessions
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+def _seed_project(conn: sqlite3.Connection, name: str = "testproj") -> int:
+    """Insert a project row and return its id."""
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO projects (path, key, name) VALUES (?, ?, ?)",
+        (f"/{name}", f"-{name}", name),
+    )
+    conn.commit()
+    return cursor.lastrowid
+
+
+def _seed_session(conn: sqlite3.Connection, project_id: int, uuid: str = "sess-1") -> int:
+    """Insert a session row and return its id."""
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO sessions (uuid, project_id) VALUES (?, ?)",
+        (uuid, project_id),
+    )
+    conn.commit()
+    return cursor.lastrowid
+
+
+def _seed_branch(
+    conn: sqlite3.Connection,
+    session_id: int,
+    context_summary: str | None = "A precomputed summary.",
+    aggregated_content: str = "some content",
+    leaf_uuid: str = "leaf-1",
+) -> int:
+    """Insert a branch row and return its id."""
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO branches
+            (session_id, leaf_uuid, is_active, exchange_count,
+             started_at, ended_at, context_summary, aggregated_content)
+        VALUES
+            (?, ?, 1, 3,
+             datetime('now', '-2 hours'), datetime('now', '-1 hour'), ?, ?)
+        """,
+        (session_id, leaf_uuid, context_summary, aggregated_content),
+    )
+    conn.commit()
+    return cursor.lastrowid
+
+
+def _seed_message(
+    conn: sqlite3.Connection,
+    session_id: int,
+    branch_id: int,
+    role: str = "user",
+    content: str = "Hello world",
+) -> int:
+    """Insert a message and link it to a branch; return message id."""
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, datetime('now'))",
+        (session_id, role, content),
+    )
+    msg_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO branch_messages (branch_id, message_id) VALUES (?, ?)",
+        (branch_id, msg_id),
+    )
+    conn.commit()
+    return msg_id
+
+
+# ---------------------------------------------------------------------------
+# 1. volume_signal — boundary and hint direction
+# ---------------------------------------------------------------------------
+
+class TestVolumeSignal:
+    """volume_signal classifies output size mechanically; no guessing or I/O."""
+
+    def test_just_under_threshold_is_not_large(self):
+        """49 999 chars must not trigger the large signal."""
+        is_large, hint = volume_signal(FANOUT_SUGGEST_CHARS - 1, False)
+        assert is_large is False
+        assert hint == ""
+
+    def test_at_threshold_is_not_large(self):
+        """Exactly 50 000 chars falls on the non-large side (strict >)."""
+        is_large, hint = volume_signal(FANOUT_SUGGEST_CHARS, False)
+        assert is_large is False
+        assert hint == ""
+
+    def test_just_over_threshold_is_large(self):
+        """50 001 chars must trigger the large signal."""
+        is_large, hint = volume_signal(FANOUT_SUGGEST_CHARS + 1, False)
+        assert is_large is True
+        assert hint != ""
+
+    def test_full_mode_hint_suggests_summary(self):
+        """In full mode, the hint must steer toward --summary, not fan-out."""
+        _, hint = volume_signal(FANOUT_SUGGEST_CHARS + 1, False)
+        assert "--summary" in hint
+        # Must NOT tell the caller to fan out first (that's the summary-mode hint)
+        assert "fan out" not in hint.split("--summary")[0]
+
+    def test_summary_mode_hint_suggests_fanout(self):
+        """In summary mode, even summaries are large — hint must steer toward fan-out."""
+        _, hint = volume_signal(FANOUT_SUGGEST_CHARS + 1, True)
+        assert "fan out" in hint
+        assert "exceeds" in hint
+
+    def test_small_output_returns_empty_hint_in_summary_mode(self):
+        """Small output is quiet regardless of summary mode."""
+        is_large, hint = volume_signal(FANOUT_SUGGEST_CHARS - 1, True)
+        assert is_large is False
+        assert hint == ""
+
+    def test_zero_chars_is_not_large(self):
+        """Zero chars — empty result set — must never trigger the signal."""
+        is_large, hint = volume_signal(0, False)
+        assert is_large is False
+        assert hint == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. format_markdown_session — summary branch
+# ---------------------------------------------------------------------------
+
+class TestFormatMarkdownSessionSummaryBranch:
+    """format_markdown_session(session) with a 'summary' key takes a fast path."""
+
+    def _base_session(self, **overrides) -> dict:
+        s = {
+            "uuid": "abcdef12-0000-0000-0000-000000000000",
+            "project": "myproj",
+            "started_at": "2025-03-10T10:00:00Z",
+            "messages": [{"role": "user", "content": "Should not appear"}],
+        }
+        s.update(overrides)
+        return s
+
+    def test_summary_key_emits_summary_heading(self):
+        """When session has 'summary', output contains ### Summary."""
+        md = format_markdown_session(self._base_session(summary="Got it."))
+        assert "### Summary" in md
+
+    def test_summary_key_skips_conversation_heading(self):
+        """The ### Conversation block must be absent when summary key is present."""
+        md = format_markdown_session(self._base_session(summary="Got it."))
+        assert "### Conversation" not in md
+
+    def test_summary_key_skips_message_content(self):
+        """Message rows must not be rendered when summary key is present."""
+        md = format_markdown_session(self._base_session(summary="Got it."))
+        assert "Should not appear" not in md
+
+    def test_summary_text_is_present_in_output(self):
+        """The literal summary text must appear in the rendered markdown."""
+        md = format_markdown_session(self._base_session(summary="Implemented caching."))
+        assert "Implemented caching." in md
+
+    def test_empty_string_summary_renders_placeholder(self):
+        """Empty string summary → placeholder, not a blank block."""
+        md = format_markdown_session(self._base_session(summary=""))
+        assert "summary unavailable" in md
+        assert "### Summary" in md
+
+    def test_whitespace_only_summary_renders_placeholder(self):
+        """Whitespace-only summary is treated as blank; placeholder is shown."""
+        md = format_markdown_session(self._base_session(summary="   \n  "))
+        assert "summary unavailable" in md
+
+    def test_placeholder_does_not_contain_user_content(self):
+        """Placeholder must not accidentally include message content."""
+        md = format_markdown_session(self._base_session(summary=""))
+        assert "Should not appear" not in md
+
+    def test_no_summary_key_still_renders_conversation(self):
+        """Absence of 'summary' key falls through to the normal Conversation path."""
+        session = self._base_session()
+        del session["messages"]
+        session["messages"] = [{"role": "user", "content": "Normal message"}]
+        md = format_markdown_session(session)
+        assert "### Conversation" in md
+        assert "Normal message" in md
+
+    def test_output_ends_with_separator(self):
+        """Both summary and full paths end with the --- separator."""
+        md_sum = format_markdown_session(self._base_session(summary="x"))
+        md_full = format_markdown_session(self._base_session())
+        assert md_sum.endswith("---\n")
+        assert md_full.endswith("---\n")
+
+
+# ---------------------------------------------------------------------------
+# 3. get_recent_sessions — summary=True vs default
+# ---------------------------------------------------------------------------
+
+class TestGetRecentSessionsSummaryMode:
+    """Verify summary routing in get_recent_sessions against the in-memory DB."""
+
+    def _setup_one_session(
+        self,
+        memory_db: sqlite3.Connection,
+        context_summary: str | None = "Precomputed summary text.",
+    ) -> None:
+        proj_id = _seed_project(memory_db)
+        sess_id = _seed_session(memory_db, proj_id)
+        branch_id = _seed_branch(memory_db, sess_id, context_summary=context_summary)
+        _seed_message(memory_db, sess_id, branch_id, content="Actual message content")
+
+    def test_default_mode_emits_messages(self, memory_db: sqlite3.Connection):
+        """Without summary=True, session data contains 'messages' with content."""
+        self._setup_one_session(memory_db)
+        results = get_recent_sessions(
+            memory_db, limit=5, sort_order="desc",
+            before=None, after=None, projects=["testproj"],
+            verbose=False, include_notifications=False,
+        )
+        assert len(results) == 1
+        assert "messages" in results[0]
+        assert results[0]["messages"][0]["content"] == "Actual message content"
+
+    def test_default_mode_omits_summary_key(self, memory_db: sqlite3.Connection):
+        """Full mode must not include a 'summary' key in the result dict."""
+        self._setup_one_session(memory_db)
+        results = get_recent_sessions(
+            memory_db, limit=5, sort_order="desc",
+            before=None, after=None, projects=["testproj"],
+            verbose=False, include_notifications=False,
+        )
+        assert "summary" not in results[0]
+
+    def test_summary_mode_emits_precomputed_text(self, memory_db: sqlite3.Connection):
+        """summary=True must set 'summary' to the branch's context_summary."""
+        self._setup_one_session(memory_db, context_summary="Precomputed summary text.")
+        results = get_recent_sessions(
+            memory_db, limit=5, sort_order="desc",
+            before=None, after=None, projects=["testproj"],
+            verbose=False, include_notifications=False,
+            summary=True,
+        )
+        assert len(results) == 1
+        assert results[0]["summary"] == "Precomputed summary text."
+
+    def test_summary_mode_skips_message_query(self, memory_db: sqlite3.Connection):
+        """summary=True must not include a 'messages' key — no per-message query fires."""
+        self._setup_one_session(memory_db)
+        results = get_recent_sessions(
+            memory_db, limit=5, sort_order="desc",
+            before=None, after=None, projects=["testproj"],
+            verbose=False, include_notifications=False,
+            summary=True,
+        )
+        assert "messages" not in results[0]
+
+    def test_null_context_summary_becomes_empty_string(self, memory_db: sqlite3.Connection):
+        """NULL context_summary in DB → 'summary' key is empty string, not None or crash."""
+        self._setup_one_session(memory_db, context_summary=None)
+        results = get_recent_sessions(
+            memory_db, limit=5, sort_order="desc",
+            before=None, after=None, projects=["testproj"],
+            verbose=False, include_notifications=False,
+            summary=True,
+        )
+        assert results[0]["summary"] == ""
+
+    def test_summary_mode_result_is_json_serialisable(self, memory_db: sqlite3.Connection):
+        """Summary dicts must round-trip through JSON (no non-serialisable types)."""
+        import json
+        self._setup_one_session(memory_db)
+        results = get_recent_sessions(
+            memory_db, limit=5, sort_order="desc",
+            before=None, after=None, projects=["testproj"],
+            verbose=False, include_notifications=False,
+            summary=True,
+        )
+        # Should not raise
+        json.dumps(results)
+
+
+# ---------------------------------------------------------------------------
+# 4. JSON meta flag truth table  (is_large × summary_mode → 4 states)
+#
+# Seam note: both recall scripts build their JSON meta from the shared
+# cli_common.volume_flags() helper. This test calls that same helper directly,
+# so it guards the production derivation (not a copy). Invoking main() would add
+# process-level mocking (DB path, argparse, stdout capture) without exercising
+# more logic than volume_flags() already exposes.
+# ---------------------------------------------------------------------------
+
+class TestJsonMetaFlagTruthTable:
+    """Pin the 4-state flag derivation that drives agent routing decisions."""
+
+    def _flags(self, output_chars: int, summary_mode: bool) -> tuple[bool, bool]:
+        """Call the SAME shared helper both recall scripts use to build JSON meta,
+        so this test guards production rather than a copy of the logic."""
+        m = volume_flags(output_chars, summary_mode)
+        return m["summary_suggested"], m["fanout_suggested"]
+
+    def test_small_full_both_false(self):
+        """Small volume, full mode → neither flag set."""
+        summary_suggested, fanout_suggested = self._flags(FANOUT_SUGGEST_CHARS, False)
+        assert summary_suggested is False
+        assert fanout_suggested is False
+
+    def test_large_full_summary_suggested(self):
+        """Large volume, full mode → summary_suggested=True, fanout_suggested=False."""
+        summary_suggested, fanout_suggested = self._flags(FANOUT_SUGGEST_CHARS + 1, False)
+        assert summary_suggested is True
+        assert fanout_suggested is False
+
+    def test_large_summary_fanout_suggested(self):
+        """Large volume, summary mode → fanout_suggested=True, summary_suggested=False."""
+        summary_suggested, fanout_suggested = self._flags(FANOUT_SUGGEST_CHARS + 1, True)
+        assert summary_suggested is False
+        assert fanout_suggested is True
+
+    def test_small_summary_both_false(self):
+        """Small volume, summary mode → neither flag set (summary already helped)."""
+        summary_suggested, fanout_suggested = self._flags(FANOUT_SUGGEST_CHARS, True)
+        assert summary_suggested is False
+        assert fanout_suggested is False
+
+    def test_flags_are_mutually_exclusive_when_large(self):
+        """summary_suggested and fanout_suggested can never both be True."""
+        for summary_mode in (False, True):
+            ss, fs = self._flags(FANOUT_SUGGEST_CHARS + 1, summary_mode)
+            assert not (ss and fs), (
+                f"Both flags True for summary_mode={summary_mode} — violates mutual exclusivity"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 5. search_sessions — summary parity (LIKE fallback path)
+# ---------------------------------------------------------------------------
+
+class TestSearchSessionsSummaryMode:
+    """search_sessions(summary=True) routes to context_summary, not messages."""
+
+    def _setup_searchable_session(self, memory_db: sqlite3.Connection) -> None:
+        proj_id = _seed_project(memory_db, name="searchproj")
+        sess_id = _seed_session(memory_db, proj_id, uuid="search-sess-1")
+        _seed_branch(
+            memory_db, sess_id,
+            context_summary="Search precomputed summary.",
+            aggregated_content="findable keyword here",
+        )
+        _seed_message(memory_db, sess_id, _get_last_branch_id(memory_db), content="findable keyword here")
+
+    def test_full_mode_returns_messages(self, memory_db: sqlite3.Connection):
+        """LIKE search without summary=True returns messages, not summary."""
+        self._setup_searchable_session(memory_db)
+        results = search_sessions(
+            memory_db, query="findable", fts_level=None,
+            limit=5, projects=["searchproj"],
+            verbose=False, include_notifications=False,
+            summary=False,
+        )
+        assert len(results) == 1
+        assert "messages" in results[0]
+        assert "summary" not in results[0]
+
+    def test_summary_mode_returns_context_summary(self, memory_db: sqlite3.Connection):
+        """LIKE search with summary=True returns context_summary instead of messages."""
+        self._setup_searchable_session(memory_db)
+        results = search_sessions(
+            memory_db, query="findable", fts_level=None,
+            limit=5, projects=["searchproj"],
+            verbose=False, include_notifications=False,
+            summary=True,
+        )
+        assert len(results) == 1
+        assert results[0]["summary"] == "Search precomputed summary."
+        assert "messages" not in results[0]
+
+    def test_summary_mode_null_db_summary_becomes_empty_string(self, memory_db: sqlite3.Connection):
+        """NULL context_summary in DB → empty string, not None or crash."""
+        proj_id = _seed_project(memory_db, name="searchproj2")
+        sess_id = _seed_session(memory_db, proj_id, uuid="search-sess-null")
+        _seed_branch(
+            memory_db, sess_id,
+            context_summary=None,
+            aggregated_content="unique keyword zxqwerty",
+            leaf_uuid="leaf-null",
+        )
+        _seed_message(memory_db, sess_id, _get_last_branch_id(memory_db), content="unique keyword zxqwerty")
+        results = search_sessions(
+            memory_db, query="unique keyword zxqwerty", fts_level=None,
+            limit=5, projects=["searchproj2"],
+            verbose=False, include_notifications=False,
+            summary=True,
+        )
+        assert len(results) == 1
+        assert results[0]["summary"] == ""
+
+
+def _get_last_branch_id(conn: sqlite3.Connection) -> int:
+    """Return the most recently inserted branch id."""
+    return conn.execute("SELECT MAX(id) FROM branches").fetchone()[0]

--- a/tests/claude-memory/test_summary_mode.py
+++ b/tests/claude-memory/test_summary_mode.py
@@ -420,3 +420,62 @@ class TestSearchSessionsSummaryMode:
 def _get_last_branch_id(conn: sqlite3.Connection) -> int:
     """Return the most recently inserted branch id."""
     return conn.execute("SELECT MAX(id) FROM branches").fetchone()[0]
+
+
+# ---------------------------------------------------------------------------
+# 6. Regression: unmigrated DB missing the context_summary column.
+#    Both PR reviewers flagged that an unconditional `SELECT b.context_summary`
+#    crashes a normal recall on a DB created before the migration. recall must
+#    degrade gracefully: full mode works, summary mode falls back to "".
+# ---------------------------------------------------------------------------
+
+class TestMissingContextSummaryColumn:
+    """recall must not fail with 'no such column' on a pre-migration database."""
+
+    def _seed_then_drop_column(self, conn: sqlite3.Connection) -> None:
+        proj_id = _seed_project(conn, name="oldproj")
+        sess_id = _seed_session(conn, proj_id, uuid="old-sess-1")
+        branch_id = _seed_branch(
+            conn, sess_id,
+            context_summary="will be dropped",
+            aggregated_content="legacy aggregated content",
+        )
+        _seed_message(conn, sess_id, branch_id, content="legacy message")
+        # Simulate a DB created before the context_summary migration ran.
+        conn.execute("ALTER TABLE branches DROP COLUMN context_summary")
+        conn.commit()
+
+    def test_recent_full_mode_survives_missing_column(self, memory_db: sqlite3.Connection):
+        """A normal (non-summary) recall must not crash on a pre-migration DB."""
+        self._seed_then_drop_column(memory_db)
+        results = get_recent_sessions(
+            memory_db, limit=5, sort_order="desc",
+            before=None, after=None, projects=["oldproj"],
+            verbose=False, include_notifications=False,
+        )
+        assert len(results) == 1
+        assert results[0]["messages"][0]["content"] == "legacy message"
+
+    def test_recent_summary_mode_falls_back_to_empty(self, memory_db: sqlite3.Connection):
+        """summary=True on a pre-migration DB yields '' rather than crashing."""
+        self._seed_then_drop_column(memory_db)
+        results = get_recent_sessions(
+            memory_db, limit=5, sort_order="desc",
+            before=None, after=None, projects=["oldproj"],
+            verbose=False, include_notifications=False,
+            summary=True,
+        )
+        assert len(results) == 1
+        assert results[0]["summary"] == ""
+
+    def test_search_summary_mode_survives_missing_column(self, memory_db: sqlite3.Connection):
+        """LIKE search with summary=True must not crash on a pre-migration DB."""
+        self._seed_then_drop_column(memory_db)
+        results = search_sessions(
+            memory_db, query="legacy", fts_level=None,
+            limit=5, projects=["oldproj"],
+            verbose=False, include_notifications=False,
+            summary=True,
+        )
+        assert len(results) == 1
+        assert results[0]["summary"] == ""

--- a/tests/claude-memory/test_summary_mode.py
+++ b/tests/claude-memory/test_summary_mode.py
@@ -11,12 +11,13 @@ Coverage:
 
 from __future__ import annotations
 
+import json
 import sqlite3
 
 import pytest
 
 from memory_lib.cli_common import FANOUT_SUGGEST_CHARS, volume_flags, volume_signal
-from memory_lib.formatting import format_markdown_session
+from memory_lib.formatting import format_json_sessions, format_markdown_session
 from recent_chats import get_recent_sessions
 from search_conversations import search_sessions
 
@@ -479,3 +480,26 @@ class TestMissingContextSummaryColumn:
         )
         assert len(results) == 1
         assert results[0]["summary"] == ""
+
+
+# ---------------------------------------------------------------------------
+# 7. JSON session counters — summary mode must not report a misleading
+#    total_messages: 0 (it carries 'summary', not 'messages').
+# ---------------------------------------------------------------------------
+
+class TestJsonSessionCounters:
+    """format_json_sessions reports the counter that matches the retrieval mode."""
+
+    def test_full_mode_reports_total_messages(self):
+        """Full sessions report total_messages and no total_summaries key."""
+        sessions = [{"uuid": "a", "messages": [{"role": "user", "content": "hi"}]}]
+        out = json.loads(format_json_sessions(sessions))
+        assert out["total_messages"] == 1
+        assert "total_summaries" not in out
+
+    def test_summary_mode_reports_total_summaries_not_zero_messages(self):
+        """Summary sessions report total_summaries, NOT a misleading total_messages: 0."""
+        sessions = [{"uuid": "a", "summary": "s1"}, {"uuid": "b", "summary": "s2"}]
+        out = json.loads(format_json_sessions(sessions))
+        assert out["total_summaries"] == 2
+        assert "total_messages" not in out


### PR DESCRIPTION
## What

Adds a `--summary` retrieval mode and a mechanical volume-based fan-out signal to the `recall-conversations` skill, so broad/retrospective queries stop flooding the main context.

## Why

A taxonomy of 61 real historical recall invocations showed two populations:

- ~72% are `continuation-restore` / `specific-lookup` — small targeted answers; fan-out would only add latency.
- ~30% are `broad-retro-synthesis` / `gap-antipattern` / `decision-extraction` — high blast radius, heavy consume.

Investigating the heavy cluster surfaced the load-bearing fact: the recall scripts emit **full untruncated transcripts** (`formatting.py` renders every `m.content`). The precomputed `context_summary` column exists (94% populated, written at import time by `summarizer.py`) but recall never read it. So `recent_chats.py --limit 20 --verbose` (the run-retro recipe) was pouring ~20 full transcripts into context.

## How — two tiers, gated by measured volume (not session count)

1. **`--summary`** (tier 1): emit the precomputed `context_summary` instead of full content. Single-pass, free at query time, skips the per-message query. Measured ~3x reduction (309,798 → 85,885 chars on a 20-session retro).
2. **Fan out** (tier 2): only when even summaries overflow. The scripts emit a two-tier signal via a shared `cli_common.volume_flags()` helper — `summary_suggested` (large full pull → use `--summary`) and `fanout_suggested` (large even after `--summary` → fan out), plus an `INFO:` stderr nudge in markdown mode. `SKILL.md` step 4 documents per-project `general-purpose` fan-out (shard by project, never by arbitrary count — count splits sever a decision/antipattern thread).

Triggering keys on lens type + measured output volume, never raw session count — `continuation-restore` and `specific-lookup` (the 72%) never escalate.

## Changes

- `scripts/memory_lib/cli_common.py` — `--summary` flag, `FANOUT_SUGGEST_CHARS`, `volume_signal()`, `volume_flags()` (single source of truth for both scripts' JSON meta), `emit_volume_signal()`.
- `scripts/recent_chats.py` / `search_conversations.py` — `summary` routing + JSON meta via `volume_flags()`.
- `scripts/memory_lib/formatting.py` — summary branch in `format_markdown_session` (early return; placeholder for empty summary).
- `SKILL.md` — gated step-4 escalation + `Agent` in `allowed-tools`.
- `references/tool-reference.md` — `--summary` rows + signal docs.

## Testing

- New `tests/claude-memory/test_summary_mode.py` — 30 tests: `volume_signal` boundaries (49999/50000/50001), formatter summary branch, summary-mode routing in both scripts (via the in-memory `memory_db` fixture), and the JSON-meta truth table called through the shared `volume_flags()` helper (guards production, not a copy).
- Fixed 2 stale footer assertions in `test_context_injection.py` (the footer now emits the canonical `claude-memory:recall-conversations` name).
- Full `tests/claude-memory` suite: **448 passed, 0 failed**.

## Notes

- Version auto-bumped 0.8.104 → 0.8.105 by the `auto-version` pre-commit hook.
- Adding `Agent` to `allowed-tools` widens the skill's tool surface; it is gated behind the rare tier-2 path so the common 72% of calls are unaffected.
