### PR TITLE
feat(skills): add API/HAR input and data-layer scorecard to create-cli

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "name": "claude-skills",
       "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
-      "version": "0.5.27",
+      "version": "0.5.28",
       "source": "./plugins/claude-skills"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     {
       "name": "claude-skills",
       "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
-      "version": "0.5.26",
+      "version": "0.5.27",
       "source": "./plugins/claude-skills"
     },
     {

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Coding workflow skills for Claude Code. Nine skills and five agents covering the
 
 <a id="claude-skills"></a>
 
-### ✍️ claude-skills &nbsp; ![v0.5.26](https://img.shields.io/badge/v0.5.26-blue?style=flat-square)
+### ✍️ claude-skills &nbsp; ![v0.5.27](https://img.shields.io/badge/v0.5.27-blue?style=flat-square)
 
 Skill authoring tools for Claude Code. Six skills covering the full lifecycle from creation to repair.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Coding workflow skills for Claude Code. Nine skills and five agents covering the
 
 <a id="claude-skills"></a>
 
-### ✍️ claude-skills &nbsp; ![v0.5.27](https://img.shields.io/badge/v0.5.27-blue?style=flat-square)
+### ✍️ claude-skills &nbsp; ![v0.5.28](https://img.shields.io/badge/v0.5.28-blue?style=flat-square)
 
 Skill authoring tools for Claude Code. Six skills covering the full lifecycle from creation to repair.
 

--- a/plugins/claude-skills/.claude-plugin/plugin.json
+++ b/plugins/claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-skills/.claude-plugin/plugin.json
+++ b/plugins/claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-skills",
-  "version": "0.5.26",
+  "version": "0.5.27",
   "description": "Skill and agent authoring tools: generate, audit, and improve Claude Code skills, commands, and agents",
   "author": {
     "name": "Samarth Gupta"

--- a/plugins/claude-skills/README.md
+++ b/plugins/claude-skills/README.md
@@ -1,4 +1,4 @@
-# claude-skills ![v0.5.26](https://img.shields.io/badge/v0.5.26-blue?style=flat-square)
+# claude-skills ![v0.5.27](https://img.shields.io/badge/v0.5.27-blue?style=flat-square)
 
 Skill and agent authoring tools for Claude Code. Six complementary skills: one generates skills from scratch, one generates agents, one audits skills for structural correctness, one audits agents for structural correctness, one improves skills for effectiveness, and one designs CLI interfaces for the scripts those skills produce. A bundled `skill-lint` agent runs structural linting automatically after skill creation or improvement.
 

--- a/plugins/claude-skills/README.md
+++ b/plugins/claude-skills/README.md
@@ -1,4 +1,4 @@
-# claude-skills ![v0.5.27](https://img.shields.io/badge/v0.5.27-blue?style=flat-square)
+# claude-skills ![v0.5.28](https://img.shields.io/badge/v0.5.28-blue?style=flat-square)
 
 Skill and agent authoring tools for Claude Code. Six complementary skills: one generates skills from scratch, one generates agents, one audits skills for structural correctness, one audits agents for structural correctness, one improves skills for effectiveness, and one designs CLI interfaces for the scripts those skills produce. A bundled `skill-lint` agent runs structural linting automatically after skill creation or improvement.
 

--- a/plugins/claude-skills/skills/create-cli/SKILL.md
+++ b/plugins/claude-skills/skills/create-cli/SKILL.md
@@ -82,12 +82,13 @@ If primary consumer is human-only, the Errors and Reduce Tool Calls subsections 
 
 ### Errors (agent/mixed consumers only)
 - When `--json` is active, emit error objects on stderr: `{"error": "<snake_case_code>", "message": "...", "hint": "<exact CLI invocation or null>"}` — so agent callers can route recovery logic without parsing free-text stderr. The `hint` field must be an executable command, not prose.
-- Exit codes: `0` success, `1` runtime error, `2` invalid usage; add command-specific codes only when genuinely useful.
+- Exit codes: `0` success, `1` runtime error, `2` invalid usage; for agent/mixed consumers, extend with the typed table from cli-guidelines.md → Exit codes (typed) (`3` not-found, `4` auth, `5` upstream, `7` conflict) — apply identically across all subcommands so agents branch on the code.
 
 ### Flags
 - `-h/--help` always shows help; ignores other args.
 - `--version` prints version to stdout.
 - `--json` preferred for structured output. `--output json`/`-o json` acceptable when the CLI needs multiple output formats (yaml, table, csv) under a single flag. Pick one and apply consistently.
+- For commands an agent calls in a loop, offer `--compact` (opt-in): same JSON shape, minimal whitespace, essential fields only — `--json` stays the full-fidelity default. See cli-guidelines.md → Output defaults.
 - Consistent flag names across all subcommands for the same concept (`--id`, `--force`, `--json`) — agents learn the naming pattern once and apply it everywhere without guessing.
 - Prompts only when stdin is a TTY; `--no-input` disables prompts. `--non-interactive` acceptable if the ecosystem already uses it.
 - Destructive operations: interactive confirmation; non-interactive requires `--force`.

--- a/plugins/claude-skills/skills/create-cli/SKILL.md
+++ b/plugins/claude-skills/skills/create-cli/SKILL.md
@@ -40,6 +40,8 @@ Ask, then proceed with best-guess defaults if user is unsure:
 - Primary consumer: agent/LLM, human at a terminal, scripted automation, or mixed.
 - Input sources: args vs stdin; files vs URLs; secrets (never via flags).
 - Output contract: human text by default, `--json` for structured output, exit codes.
+- Backend/data layer: does it wrap an existing API? Source of the surface — OpenAPI/docs, live URL,
+  or HAR capture (undocumented/browser-fed)? (cli-guidelines.md → Wrapping an existing API.)
 - Interactivity: prompts allowed? need `--no-input`? confirmations for destructive ops?
 - Config model: flags/env/config-file; precedence; XDG vs repo-local.
 - Language & distribution: ask for the user's preferred implementation language, or offer to
@@ -48,6 +50,11 @@ Ask, then proceed with best-guess defaults if user is unsure:
   the user is unsure. Platform: macOS/Linux/Windows.
 
 If an existing CLI spec or tool description is provided, read it first — skip questions already answered by it.
+
+**Data Layer gate** — required when the tool reads from a backend. Run the Data Layer Decision
+scorecard (cli-guidelines.md → Stateful CLIs); record `adopt cache` or `stateless` + a one-line
+rationale. Decide this before drawing the command tree — it changes whether `sync`/local-read
+subcommands exist at all.
 
 ### Audit
 
@@ -68,7 +75,7 @@ Apply the conventions from cli-guidelines.md (loaded in Phase 1), including the 
 If primary consumer is human-only, the Errors and Reduce Tool Calls subsections are optional — apply them only if the user wants script-friendliness.
 
 ### Output
-- Default output is human-readable text. `--json` gives structured JSON. Explicit is better than implicit — no TTY sniffing, no surprises.
+- Default output is human-readable text; an explicit `--json`/`--plain` flag sets the data format and overrides TTY state. Cosmetics (color, spinners) may TTY-detect; the data format must not rely on it (see cli-guidelines.md → Agent Ergonomics for the TTY/PTY rationale).
 - List commands in `--json` mode use NDJSON (one JSON object per line) — enables streaming and `jq` piping without buffering. For paginated results with metadata, a JSON object with an `items` array is acceptable. If the CLI extends an existing ecosystem that uses JSON arrays (kubectl, aws, gh), match the ecosystem convention.
 - Primary data to stdout; diagnostics/errors to stderr.
 - Suppress ANSI codes, progress spinners, and decorative output when `--json` is passed or when stdout is not a TTY.
@@ -106,6 +113,7 @@ Evaluate the existing CLI against every Phase 3 subsection. For each convention,
 - Config precedence (flags > env > project config > user config > defaults).
 - Destructive-op safety (confirmations, --force, --dry-run).
 - Shell completion availability.
+- Data layer fit: if the CLI reads from a backend, run the Data Layer Decision scorecard; flag when it re-fetches live data that a local cache + compound queries would serve (cli-guidelines.md → Stateful CLIs).
 
 Produce a gap report organized by severity: Breaking (requires API change), Major (agent-breaking or convention violation), Minor (cosmetic/polish). Each finding: current behavior, convention violated, recommended fix with migration risk (none/low/breaking).
 
@@ -120,6 +128,8 @@ Produce a compact spec the user can implement. Include all relevant sections:
 - Error + exit code map (top failure modes).
 - Safety rules: `--dry-run`, confirmations, `--force`, `--no-input`.
 - Config/env rules + precedence (flags > env > project config > user config > system).
+- Data layer decision: `adopt cache` | `stateless` verdict + rationale (required when the tool reads from a backend).
+- API provenance (when wrapping an existing API): source + endpoint→command mapping; for HAR, the secret/auth/coverage/fragility/ToS checks.
 - Shell completion story (if relevant): install/discoverability; generation command or bundled scripts.
 - 5–10 example invocations (common flows; include piped/stdin examples).
 
@@ -150,7 +160,12 @@ Use this skeleton, dropping irrelevant sections:
 8. **Env/config**:
    - env vars:
    - config file path + precedence:
-9. **Examples**:
+9. **Data Layer Decision** (required when the tool reads from a backend; omit if no backend):
+   `adopt cache` | `stateless` + one-line rationale. If `adopt`: `sync` command, local schema
+   sketch, local-vs-live reads, write invalidation note.
+10. **API Provenance** (only when wrapping an existing API; omit for from-scratch tools):
+    source (OpenAPI/URL/HAR); subcommand ← method+path mapping; for HAR, the five checks.
+11. **Examples**:
    - …
 
 See `${CLAUDE_PLUGIN_ROOT}/skills/create-cli/examples/example-cli-spec.md` for a complete worked example.
@@ -160,6 +175,8 @@ If the spec is destined for a skill body or CLAUDE.md, omit unused sections enti
 ## Phase 5 — Verify
 
 For new specs: confirm the spec covers all applicable sections from the Phase 4 skeleton. Verify the examples section demonstrates at least: `--json` output, error recovery (if agent/mixed consumer), and one piped/stdin usage.
+
+For backend/API-wrapping specs: confirm a Data Layer Decision verdict is recorded with a rationale (not left implicit), and — when the source is a HAR/undocumented API — that no secret values appear anywhere in the spec (only env-var names) and the coverage/fragility caveats are stated.
 
 For audits: confirm the gap report addresses every Phase 3 subsection and includes at least one example invocation showing the recommended fix for each Major finding.
 

--- a/plugins/claude-skills/skills/create-cli/references/cli-guidelines.md
+++ b/plugins/claude-skills/skills/create-cli/references/cli-guidelines.md
@@ -277,8 +277,8 @@ calls total.
 - Extend the base set (`0` success, `1` generic runtime, `2` usage/validation) with a small
   fixed table applied identically across every subcommand, so agents branch on the code instead
   of parsing stderr: `3` not-found, `4` auth/permission, `5` upstream/network, `7`
-  conflict/precondition. Skip codes that don't apply; never renumber once shipped — the table is
-  a contract.
+  conflict/precondition (`6` is reserved — skip it). Skip codes that don't apply; never renumber
+  once shipped — the table is a contract.
 - Pair each non-zero code with the `hint` command an agent can run to recover.
 
 ### Reduce tool calls

--- a/plugins/claude-skills/skills/create-cli/references/cli-guidelines.md
+++ b/plugins/claude-skills/skills/create-cli/references/cli-guidelines.md
@@ -250,13 +250,20 @@ calls total.
 
 ### Output defaults
 
-- Default output is human-readable text. `--json` gives structured JSON. Explicit is better
-  than implicit — no TTY sniffing, no surprises. Agents pass `--json`; humans get readable
-  output without any flags.
+- Data format (JSON vs human text) follows an explicit `--json`/`--plain` flag that overrides
+  TTY state — never TTY alone. Agents pass the flag and must not rely on auto-detection: some
+  harnesses allocate a PTY, which would silently flip an auto-detecting tool to human tables and
+  break the parser. TTY-detecting the *default* (table on a TTY, JSON when piped) is fine for
+  human-primary tools, but only with the explicit override as the documented stable contract.
+- Cosmetics (color, spinners, progress, pagers, decorative output) TTY-detect always; suppress
+  when piped, `NO_COLOR`, `TERM=dumb`, or `--json`.
 - List commands in `--json` mode: NDJSON (one object per line) — enables streaming and `jq`
   piping without buffering. For paginated results with metadata, a JSON object with an
   `items` array is acceptable.
-- Suppress ANSI codes, progress indicators, and decorative output when `--json` is active.
+- For high-frequency agent calls, offer `--compact`: same JSON shape, minimal whitespace, only
+  essential fields (drop verbose/derived ones). `--json` stays the full-fidelity default;
+  `--compact` is the opt-in mode for commands an agent calls in a loop, where per-call token
+  cost compounds.
 
 ### Structured errors
 
@@ -264,6 +271,15 @@ calls total.
   `{"error": "<snake_case_code>", "message": "<sentence>", "hint": "<exact CLI invocation or null>"}`
 - `hint` must be an executable command the agent can run directly — not a prose suggestion.
   Good: `"hint": "snapr list --json"`. Bad: `"hint": "Check available snapshots first."`.
+
+### Exit codes (typed)
+
+- Extend the base set (`0` success, `1` generic runtime, `2` usage/validation) with a small
+  fixed table applied identically across every subcommand, so agents branch on the code instead
+  of parsing stderr: `3` not-found, `4` auth/permission, `5` upstream/network, `7`
+  conflict/precondition. Skip codes that don't apply; never renumber once shipped — the table is
+  a contract.
+- Pair each non-zero code with the `hint` command an agent can run to recover.
 
 ### Reduce tool calls
 
@@ -277,6 +293,63 @@ calls total.
   the pattern once and apply it everywhere.
 - Idempotency: document which commands are safe to repeat. Agents rely on idempotency for
   error recovery without human intervention.
+
+### Stateful CLIs (local cache)
+
+Most CLIs are stateless wrappers — one command, one backend call. When the same data is queried
+repeatedly, or the useful questions span entities the backend can't join in a single call, a
+local cache earns its complexity:
+
+- `sync` pulls from the backend incrementally (cursor / updated-since) into local SQLite.
+  Subsequent `list`/`search`/`filter` read local — fast, offline, rate-limit-free, deterministic
+  within a snapshot.
+- Full-text search (SQLite FTS5) and compound queries (joins/aggregates the API has no single
+  endpoint for, e.g. "stale items whose blockers sat >7d") collapse N round-trips into one local
+  command — the largest token and tool-call saving available.
+- Cost: staleness, local storage, sync/cursor logic, schema design. Adopt only when the access
+  pattern justifies it; a pure pass-through CLI stays stateless.
+
+**Data Layer Decision (required scorecard).** For any CLI that reads from a backend, score these
+five signals and record the verdict in the spec — a `stateless` verdict must be as deliberate as
+an `adopt` one:
+
+| # | Signal | Weight |
+|---|--------|--------|
+| 1 | Read-heavy (reads ≫ writes) | support |
+| 2 | Same data feeds many questions over time | support |
+| 3 | Compound / cross-entity / cross-period queries the API has no single endpoint for | STRONG |
+| 4 | Fetches expensive or rate-limited | support |
+| 5 | Staleness-tolerant (NOT must-be-live) | GATE |
+
+- Signal 5 = NO → **stateless** (live correctness wins; stop here).
+- Signal 3 = YES and 5 = YES → **adopt cache** (the decisive combo).
+- Otherwise: 2+ support signals and 5 = YES → adopt; else stateless.
+
+If `adopt`, the spec must specify: the `sync` command (incremental cursor), a local schema sketch
+(tables + FTS5 if search is needed), which reads go local vs stay live, and that writes always go
+live with a read-after-write invalidation note.
+
+### Wrapping an existing API (input provenance)
+
+When the CLI wraps an existing backend, the command surface is *derived from* an API rather than
+designed from scratch. Record where that surface came from:
+
+- API source: documented (OpenAPI / docs), a live URL, or a **HAR capture** (DevTools → Network →
+  Export) that surfaces an undocumented, browser-fed API where no official spec exists.
+- Map the endpoint inventory to the command tree and keep a **provenance appendix**: each
+  subcommand ← method + path + a sample request.
+
+A HAR / undocumented source adds five non-negotiable design checks:
+
+- **Secrets are radioactive.** A HAR contains live cookies, tokens, and PII. Extract *structure*
+  only; parameterize every credential as an env-var NAME, never echo a value into the spec.
+- **Auth model.** Identify cookie / bearer / CSRF and how it enters the CLI (env var, never a
+  flag); note token expiry.
+- **Coverage.** A HAR is sampled — only endpoints you exercised appear. Mark which surfaces are
+  covered vs unknown; don't imply completeness.
+- **Fragility.** Undocumented endpoints have no contract and can change without notice. Isolate
+  the endpoint-mapping layer so a break is a one-line patch.
+- **ToS/legal.** Replaying a private API may violate terms. Surface this to the user; never assume.
 
 ### Discovery
 


### PR DESCRIPTION
## Summary
- feat(skills): add API/HAR input and data-layer scorecard to create-cli

## Changes
- `.claude-plugin/marketplace.json`
- `README.md`
- `plugins/claude-skills/.claude-plugin/plugin.json`
- `plugins/claude-skills/README.md`
- `plugins/claude-skills/skills/create-cli/SKILL.md`
- `plugins/claude-skills/skills/create-cli/references/cli-guidelines.md`

## Commits
- `3bec4a8` feat(skills): add API/HAR input and data-layer scorecard to create-cli

## Diff Stat
```
.claude-plugin/marketplace.json                    |  2 +-
 README.md                                          |  2 +-
 plugins/claude-skills/.claude-plugin/plugin.json   |  2 +-
 plugins/claude-skills/README.md                    |  2 +-
 plugins/claude-skills/skills/create-cli/SKILL.md   | 21 +++++-
 .../skills/create-cli/references/cli-guidelines.md | 81 ++++++++++++++++++++--
 6 files changed, 100 insertions(+), 10 deletions(-)
```