### PR TITLE
feat(memory): add --timeline + list_projects to recall CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.108",
+      "version": "0.8.109",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.109",
+      "version": "0.8.110",
       "source": "./plugins/claude-memory"
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "claude-memory",
       "description": "Searchable conversation memory with full-text search",
-      "version": "0.8.107",
+      "version": "0.8.108",
       "source": "./plugins/claude-memory"
     },
     {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.109](https://img.shields.io/badge/v0.8.109-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.110](https://img.shields.io/badge/v0.8.110-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.107](https://img.shields.io/badge/v0.8.107-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.108](https://img.shields.io/badge/v0.8.108-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable auto-updates, run `/plugin`, go to the Marketplaces tab, and toggle au
 
 <a id="claude-memory"></a>
 
-### 🧠 claude-memory &nbsp; ![v0.8.108](https://img.shields.io/badge/v0.8.108-blue?style=flat-square)
+### 🧠 claude-memory &nbsp; ![v0.8.109](https://img.shields.io/badge/v0.8.109-blue?style=flat-square)
 
 Conversation memory for Claude Code. Stores every session in a SQLite database with full-text search (FTS5, BM25 ranking, zero external dependencies) and makes past conversations available to the agent automatically.
 

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.109",
+  "version": "0.8.110",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.107",
+  "version": "0.8.108",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-memory",
   "description": "Searchable conversation memory - auto-syncs sessions to SQLite with full-text search",
-  "version": "0.8.108",
+  "version": "0.8.109",
   "author": {
     "name": "Samarth Gupta"
   },

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.108](https://img.shields.io/badge/v0.8.108-blue?style=flat-square)
+# claude-memory ![v0.8.109](https://img.shields.io/badge/v0.8.109-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.109](https://img.shields.io/badge/v0.8.109-blue?style=flat-square)
+# claude-memory ![v0.8.110](https://img.shields.io/badge/v0.8.110-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/README.md
+++ b/plugins/claude-memory/README.md
@@ -1,4 +1,4 @@
-# claude-memory ![v0.8.107](https://img.shields.io/badge/v0.8.107-blue?style=flat-square)
+# claude-memory ![v0.8.108](https://img.shields.io/badge/v0.8.108-blue?style=flat-square)
 
 Searchable conversation memory for Claude Code. Auto-syncs sessions to a SQLite database with full-text search, injects previous session context on startup, and provides on-demand recall of past conversations.
 

--- a/plugins/claude-memory/skills/recall-conversations/scripts/list_projects.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/list_projects.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+List/resolve projects in the memory database.
+
+Maps each project NAME to its canonical path + encoded key (the transcript-dir
+name), with session counts and date span. Exists because project names are NOT
+unique — the same basename (e.g. two 'EzyCopy') maps to different paths, so
+`recent_chats.py --project NAME` can silently pull the wrong project or merge
+both. Resolve here first, then target by the disambiguated name (and verify the
+path) before mining.
+
+Doubles as the sibling-directory candidate generator: --match TOKEN surfaces
+every project whose name OR path contains the token, so a project scattered
+across CWDs (e.g. a skill that began inside another repo) shows all its homes.
+
+Returns markdown by default, JSON with --json or --format json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+from memory_lib.cli_common import emit_error, open_db_or_exit, resolve_format, PLUGIN_VERSION
+from memory_lib.db import DEFAULT_DB_PATH
+
+
+EXAMPLES = """
+EXAMPLES
+  All projects, most-recently-active first:
+    list_projects.py
+
+  Resolve an ambiguous name to its path(s) + key(s):
+    list_projects.py --match EzyCopy
+
+  Find every home of a scattered project (sibling-dir discovery):
+    list_projects.py --match wiki --json | jq '.projects[] | {name, path, sessions}'
+"""
+
+
+def get_projects(conn: sqlite3.Connection, match: str | None) -> list[dict]:
+    """Return one row per project: name, path, key, session_count, date span."""
+    cursor = conn.cursor()
+    sql = """
+        SELECT p.name, p.path, p.key,
+               COUNT(DISTINCT s.id) AS sessions,
+               MIN(b.started_at) AS first_seen,
+               MAX(b.ended_at) AS last_seen
+        FROM projects p
+        LEFT JOIN sessions s ON s.project_id = p.id
+        LEFT JOIN branches b ON b.session_id = s.id AND b.is_active = 1
+    """
+    params: list = []
+    if match:
+        sql += " WHERE p.name LIKE ? OR p.path LIKE ?"
+        params.extend([f"%{match}%", f"%{match}%"])
+    sql += " GROUP BY p.id ORDER BY last_seen DESC"
+
+    cursor.execute(sql, params)
+    return [
+        {
+            "name": name,
+            "path": path,
+            "key": key,
+            "sessions": sessions,
+            "first_seen": first_seen,
+            "last_seen": last_seen,
+        }
+        for name, path, key, sessions, first_seen, last_seen in cursor.fetchall()
+    ]
+
+
+def format_markdown(rows: list[dict], match: str | None) -> str:
+    if not rows:
+        return f"No projects found{f' matching {match!r}' if match else ''}."
+    header = f"# Projects ({len(rows)}{f', matching {match!r}' if match else ''})\n"
+    lines = [header]
+    for r in rows:
+        span = f"{(r['first_seen'] or '?')[:10]}..{(r['last_seen'] or '?')[:10]}"
+        lines.append(f"- {r['name']}  [{r['sessions']} sessions, {span}]")
+        lines.append(f"    path: {r['path']}")
+        lines.append(f"    key:  {r['key']}")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="List/resolve projects in the memory database (name -> path + key).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=EXAMPLES,
+    )
+    parser.add_argument("--match", type=str, default=None,
+                        help="Substring filter over project name OR path (case-insensitive). "
+                             "Use to resolve ambiguous names or discover a project's sibling dirs.")
+    fmt_group = parser.add_mutually_exclusive_group()
+    fmt_group.add_argument("--format", choices=["markdown", "json"], default="markdown",
+                           help="Output format (default: markdown).")
+    fmt_group.add_argument("--json", action="store_true", help="Alias for --format json.")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH,
+                        help=f"Database path (default: {DEFAULT_DB_PATH}).")
+    parser.add_argument("--version", action="version",
+                        version=f"recall-conversations {PLUGIN_VERSION}")
+
+    args = parser.parse_args()
+    fmt = resolve_format(args)
+
+    conn = open_db_or_exit(args.db, fmt)
+    try:
+        rows = get_projects(conn, args.match)
+    except Exception as e:
+        emit_error("query_failed", str(e), None, fmt)
+        sys.exit(1)
+    finally:
+        conn.close()
+
+    if fmt == "json":
+        print(json.dumps({"projects": rows, "count": len(rows), "match": args.match}, indent=2))
+    else:
+        print(format_markdown(rows, args.match))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/claude-memory/skills/recall-conversations/scripts/list_projects.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/list_projects.py
@@ -55,8 +55,9 @@ def get_projects(conn: sqlite3.Connection, match: str | None) -> list[dict]:
     """
     params: list = []
     if match:
-        sql += " WHERE p.name LIKE ? OR p.path LIKE ?"
-        params.extend([f"%{match}%", f"%{match}%"])
+        sql += " WHERE p.name LIKE ? ESCAPE '\\' OR p.path LIKE ? ESCAPE '\\'"
+        escaped = match.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        params.extend([f"%{escaped}%", f"%{escaped}%"])
     sql += " GROUP BY p.id ORDER BY last_seen DESC"
 
     cursor.execute(sql, params)

--- a/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/cli_common.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/memory_lib/cli_common.py
@@ -15,9 +15,21 @@ import os
 import sqlite3
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import NamedTuple, Optional
 
 from .db import DEFAULT_DB_PATH
+
+
+class ScopeFilter(NamedTuple):
+    """A resolved project filter: which projects column to match, and the values.
+
+    column is always a literal chosen by our code ("name" or "path"), never user
+    input — safe to interpolate into SQL. values are bound as parameters. Empty
+    values means "no projects matched" and callers skip the filter.
+    """
+
+    column: str
+    values: list[str]
 
 
 def _get_plugin_version() -> str:
@@ -39,23 +51,27 @@ LIMIT_MAX = 50
 FANOUT_SUGGEST_CHARS = 50000
 
 
-def resolve_project(cwd: str, conn: sqlite3.Connection) -> Optional[list[str]]:
+def resolve_project(cwd: str, conn: sqlite3.Connection) -> Optional[ScopeFilter]:
     """
     Resolve current project from CWD by walking up the path tree against
-    projects.path in the DB. Returns [project_name] or None if no match.
+    projects.path in the DB. Returns a path-keyed ScopeFilter or None if no match.
 
     Strategy:
     1. Walk up from CWD; for each ancestor, look up projects.path = ancestor.
-    2. If no path match, try projects.name = basename(cwd) as a fallback.
+       An exact path match is unambiguous — filter by path so projects that merely
+       share a basename (duplicate names are expected — see list_projects.py) are
+       never merged into one arc.
+    2. If no path match, fall back to projects.name = basename(cwd); resolve that
+       to the path(s) of every same-named project so the filter stays path-precise.
     3. If both fail, return None — caller decides how to handle (warn + widen).
     """
     cur = os.path.abspath(cwd)
     cursor = conn.cursor()
     while True:
-        cursor.execute("SELECT name FROM projects WHERE path = ?", (cur,))
+        cursor.execute("SELECT path FROM projects WHERE path = ?", (cur,))
         row = cursor.fetchone()
         if row and row[0]:
-            return [row[0]]
+            return ScopeFilter("path", [row[0]])
         parent = os.path.dirname(cur)
         if parent == cur:
             break
@@ -63,9 +79,10 @@ def resolve_project(cwd: str, conn: sqlite3.Connection) -> Optional[list[str]]:
 
     derived = os.path.basename(os.path.abspath(cwd))
     if derived:
-        cursor.execute("SELECT 1 FROM projects WHERE name = ?", (derived,))
-        if cursor.fetchone():
-            return [derived]
+        cursor.execute("SELECT path FROM projects WHERE name = ?", (derived,))
+        paths = [r[0] for r in cursor.fetchall() if r[0]]
+        if paths:
+            return ScopeFilter("path", paths)
     return None
 
 
@@ -136,25 +153,27 @@ def resolve_scope(
     args: argparse.Namespace,
     conn: sqlite3.Connection,
     fmt: str,
-) -> tuple[Optional[list[str]], bool]:
+) -> tuple[Optional[ScopeFilter], bool]:
     """
-    Resolve project scope from args. Returns (projects_or_none, auto_detected).
+    Resolve project scope from args. Returns (scope_or_none, auto_detected).
 
     - If --all-projects: returns (None, False) — no filter.
-    - If --project NAME[,NAME]: returns ([names...], False).
-    - Otherwise: auto-detect from CWD. If auto-detect succeeds, returns ([name], True).
-      If auto-detect fails, prints stderr warning and returns (None, False) — falls
-      through to all-projects so the user gets *some* result rather than zero.
+    - If --project NAME[,NAME]: returns (ScopeFilter("name", [names...]), False) —
+      explicit names filter by name, preserving the exact requested set.
+    - Otherwise: auto-detect from CWD. On success returns (path-keyed ScopeFilter,
+      True) so same-named projects are never merged. On failure, warns and returns
+      (None, False) — falls through to all-projects so the user gets *some* result.
     """
     if args.all_projects:
         return None, False
     if args.project:
-        return [p.strip() for p in args.project.split(",") if p.strip()], False
+        names = [p.strip() for p in args.project.split(",") if p.strip()]
+        return ScopeFilter("name", names), False
 
     cwd = args.cwd or os.getcwd()
-    projects = resolve_project(cwd, conn)
-    if projects is not None:
-        return projects, True
+    scope = resolve_project(cwd, conn)
+    if scope is not None:
+        return scope, True
 
     emit_warning(
         f"Could not auto-detect project for CWD {cwd}; searching all projects. "

--- a/plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py
@@ -16,6 +16,7 @@ import sqlite3
 import sys
 
 from memory_lib.cli_common import (
+    ScopeFilter,
     add_common_args,
     emit_error,
     emit_volume_signal,
@@ -59,7 +60,7 @@ def get_recent_sessions(
     sort_order: str,
     before: str | None,
     after: str | None,
-    projects: list[str] | None,
+    scope: ScopeFilter | None,
     verbose: bool,
     include_notifications: bool,
     summary: bool = False,
@@ -95,10 +96,10 @@ def get_recent_sessions(
     if after:
         sql += " AND b.started_at > ?"
         params.append(after)
-    if projects:
-        placeholders = ",".join("?" * len(projects))
-        sql += f" AND p.name IN ({placeholders})"
-        params.extend(projects)
+    if scope and scope.values:
+        placeholders = ",".join("?" * len(scope.values))
+        sql += f" AND p.{scope.column} IN ({placeholders})"
+        params.extend(scope.values)
 
     order = "DESC" if sort_order == "desc" else "ASC"
     sql += f" ORDER BY b.ended_at {order} LIMIT ?"
@@ -169,7 +170,7 @@ def get_timeline(
     sort_order: str,
     before: str | None,
     after: str | None,
-    projects: list[str] | None,
+    scope: ScopeFilter | None,
 ) -> list[dict]:
     """Compact, UNCAPPED session index — one row per session, no message bodies.
 
@@ -203,19 +204,22 @@ def get_timeline(
     if after:
         sql += " AND b.started_at > ?"
         params.append(after)
-    if projects:
-        placeholders = ",".join("?" * len(projects))
-        sql += f" AND p.name IN ({placeholders})"
-        params.extend(projects)
+    if scope and scope.values:
+        placeholders = ",".join("?" * len(scope.values))
+        sql += f" AND p.{scope.column} IN ({placeholders})"
+        params.extend(scope.values)
 
     order = "DESC" if sort_order == "desc" else "ASC"
     sql += f" ORDER BY b.started_at {order}"  # no LIMIT — the whole arc, by design
 
     cursor.execute(sql, params)
-    rows = cursor.fetchall()
 
+    # Stream rows straight off the cursor instead of fetchall() — the no-LIMIT
+    # design means a large store could return thousands of rows, and we only ever
+    # build the compact `results` list, so materialising the raw tuples too just
+    # doubles peak memory. --before/--after remain the way to window the range.
     results = []
-    for row in rows:
+    for row in cursor:
         uuid, project, project_path, git_branch, started_at, ended_at, exchange_count = row[:7]
         col = 7
         context_summary = None
@@ -289,8 +293,8 @@ def main():
     if args.timeline:
         conn = open_db_or_exit(args.db, fmt)
         try:
-            projects, auto_detected = resolve_scope(args, conn, fmt)
-            rows = get_timeline(conn, args.sort_order, args.before, args.after, projects)
+            scope, auto_detected = resolve_scope(args, conn, fmt)
+            rows = get_timeline(conn, args.sort_order, args.before, args.after, scope)
         except Exception as e:
             emit_error("query_failed", str(e), None, fmt)
             sys.exit(1)
@@ -300,7 +304,8 @@ def main():
             print(json.dumps({
                 "timeline": rows,
                 "count": len(rows),
-                "scope": {"projects": projects, "auto_detected": auto_detected},
+                "scope": {"projects": scope.values if scope else None,
+                          "auto_detected": auto_detected},
             }, indent=2))
         else:
             print(format_timeline_markdown(rows))
@@ -310,14 +315,14 @@ def main():
 
     conn = open_db_or_exit(args.db, fmt)
     try:
-        projects, auto_detected = resolve_scope(args, conn, fmt)
+        scope, auto_detected = resolve_scope(args, conn, fmt)
         sessions = get_recent_sessions(
             conn,
             limit=limit,
             sort_order=args.sort_order,
             before=args.before,
             after=args.after,
-            projects=projects,
+            scope=scope,
             verbose=args.verbose,
             include_notifications=args.include_notifications,
             summary=args.summary,
@@ -337,7 +342,7 @@ def main():
     if fmt == "json":
         meta = {
             "scope": {
-                "projects": projects,
+                "projects": scope.values if scope else None,
                 "auto_detected": auto_detected,
             },
             "has_more": len(sessions) == limit,

--- a/plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py
@@ -280,7 +280,8 @@ def main():
     parser.add_argument("--timeline", action="store_true",
                         help="Compact UNCAPPED session index (no message bodies, no 50-limit) — "
                              "the triage primitive for reconstructing a project's full arc. "
-                             "Pair with --sort-order asc for oldest-first.")
+                             "Pair with --sort-order asc for oldest-first. "
+                             "Note: --verbose and --summary are ignored in timeline mode.")
 
     args = parser.parse_args()
     fmt = resolve_format(args)

--- a/plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py
@@ -42,6 +42,9 @@ EXAMPLES
   Time-bounded retrieval:
     recent_chats.py --after 2026-04-01 --before 2026-04-15
 
+  Full uncapped arc of a project, oldest-first (triage index, no message bodies):
+    recent_chats.py --project PKM --timeline --sort-order asc
+
   JSON output for downstream tooling:
     recent_chats.py --limit 20 --json | jq '.sessions[].project'
 
@@ -161,6 +164,106 @@ def format_markdown(sessions: list[dict], verbose: bool = False) -> str:
     return "\n".join(lines)
 
 
+def get_timeline(
+    conn: sqlite3.Connection,
+    sort_order: str,
+    before: str | None,
+    after: str | None,
+    projects: list[str] | None,
+) -> list[dict]:
+    """Compact, UNCAPPED session index — one row per session, no message bodies.
+
+    The triage primitive for reconstructing a project's full arc: a single cheap
+    call returns every session ordered by time, so a miner can see the whole shape
+    before deep-reading the dense ones. Carries project_path so ambiguous names
+    (two projects sharing a basename) stay distinguishable per-row.
+    """
+    cursor = conn.cursor()
+
+    cursor.execute("PRAGMA table_info(branches)")
+    branch_columns = {row[1] for row in cursor.fetchall()}
+    has_tool_counts = "tool_counts" in branch_columns
+    has_context_summary = "context_summary" in branch_columns
+    context_summary_col = ", b.context_summary" if has_context_summary else ""
+    tool_counts_col = ", b.tool_counts" if has_tool_counts else ""
+
+    sql = f"""
+        SELECT s.uuid, p.name as project, p.path as project_path,
+               s.git_branch, b.started_at, b.ended_at,
+               b.exchange_count{context_summary_col}{tool_counts_col}
+        FROM sessions s
+        JOIN branches b ON b.session_id = s.id AND b.is_active = 1
+        JOIN projects p ON s.project_id = p.id
+        WHERE 1=1
+    """
+    params: list = []
+    if before:
+        sql += " AND b.started_at < ?"
+        params.append(before)
+    if after:
+        sql += " AND b.started_at > ?"
+        params.append(after)
+    if projects:
+        placeholders = ",".join("?" * len(projects))
+        sql += f" AND p.name IN ({placeholders})"
+        params.extend(projects)
+
+    order = "DESC" if sort_order == "desc" else "ASC"
+    sql += f" ORDER BY b.started_at {order}"  # no LIMIT — the whole arc, by design
+
+    cursor.execute(sql, params)
+    rows = cursor.fetchall()
+
+    results = []
+    for row in rows:
+        uuid, project, project_path, git_branch, started_at, ended_at, exchange_count = row[:7]
+        col = 7
+        context_summary = None
+        if has_context_summary:
+            context_summary = row[col]
+            col += 1
+        tool_counts_json = row[col] if has_tool_counts else None
+
+        tools = 0
+        if tool_counts_json:
+            try:
+                tools = sum(json.loads(tool_counts_json).values())
+            except (ValueError, TypeError, AttributeError):
+                tools = 0
+        title = ""
+        if context_summary:
+            title = context_summary.strip().splitlines()[0][:120] if context_summary.strip() else ""
+
+        results.append({
+            "uuid": uuid,
+            "project": project,
+            "project_path": project_path,
+            "git_branch": git_branch,
+            "started_at": started_at,
+            "ended_at": ended_at,
+            "exchanges": exchange_count,
+            "tools": tools,
+            "title": title,
+        })
+    return results
+
+
+def format_timeline_markdown(rows: list[dict]) -> str:
+    if not rows:
+        return "No sessions found."
+    lines = [f"# Session Timeline ({len(rows)} sessions)\n"]
+    for r in rows:
+        date = (r["started_at"] or "")[:10]
+        branch = r["git_branch"] or "-"
+        lines.append(
+            f"- {date}  [{r['exchanges']}ex/{r['tools']}t]  ({branch})  "
+            f"{r['project']}  {r['uuid']}"
+        )
+        if r["title"]:
+            lines.append(f"    {r['title']}")
+    return "\n".join(lines)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Retrieve recent conversation sessions (defaults to current project).",
@@ -174,9 +277,34 @@ def main():
                         help="Sessions before this datetime (ISO).")
     parser.add_argument("--after", type=str,
                         help="Sessions after this datetime (ISO).")
+    parser.add_argument("--timeline", action="store_true",
+                        help="Compact UNCAPPED session index (no message bodies, no 50-limit) — "
+                             "the triage primitive for reconstructing a project's full arc. "
+                             "Pair with --sort-order asc for oldest-first.")
 
     args = parser.parse_args()
     fmt = resolve_format(args)
+
+    if args.timeline:
+        conn = open_db_or_exit(args.db, fmt)
+        try:
+            projects, auto_detected = resolve_scope(args, conn, fmt)
+            rows = get_timeline(conn, args.sort_order, args.before, args.after, projects)
+        except Exception as e:
+            emit_error("query_failed", str(e), None, fmt)
+            sys.exit(1)
+        finally:
+            conn.close()
+        if fmt == "json":
+            print(json.dumps({
+                "timeline": rows,
+                "count": len(rows),
+                "scope": {"projects": projects, "auto_detected": auto_detected},
+            }, indent=2))
+        else:
+            print(format_timeline_markdown(rows))
+        return
+
     limit = validate_limit(args, fmt)
 
     conn = open_db_or_exit(args.db, fmt)

--- a/plugins/claude-memory/skills/recall-conversations/scripts/search_conversations.py
+++ b/plugins/claude-memory/skills/recall-conversations/scripts/search_conversations.py
@@ -16,6 +16,7 @@ import sqlite3
 import sys
 
 from memory_lib.cli_common import (
+    ScopeFilter,
     add_common_args,
     emit_error,
     emit_volume_signal,
@@ -51,7 +52,7 @@ def search_sessions(
     query: str,
     fts_level: str | None,
     limit: int,
-    projects: list[str] | None,
+    scope: ScopeFilter | None,
     verbose: bool,
     include_notifications: bool,
     summary: bool = False,
@@ -90,10 +91,10 @@ def search_sessions(
         """
         params.append(fts_query)
 
-        if projects:
-            placeholders = ",".join("?" * len(projects))
-            sql += f" AND p.name IN ({placeholders})"
-            params.extend(projects)
+        if scope and scope.values:
+            placeholders = ",".join("?" * len(scope.values))
+            sql += f" AND p.{scope.column} IN ({placeholders})"
+            params.extend(scope.values)
 
         if fts_level == "fts5":
             sql += " ORDER BY bm25(branches_fts) LIMIT ?"
@@ -114,10 +115,10 @@ def search_sessions(
         """
         params.extend(f"%{term}%" for term in terms)
 
-        if projects:
-            placeholders = ",".join("?" * len(projects))
-            sql += f" AND p.name IN ({placeholders})"
-            params.extend(projects)
+        if scope and scope.values:
+            placeholders = ",".join("?" * len(scope.values))
+            sql += f" AND p.{scope.column} IN ({placeholders})"
+            params.extend(scope.values)
 
         sql += " ORDER BY b.ended_at DESC LIMIT ?"
         params.append(limit)
@@ -189,14 +190,14 @@ def main():
 
     conn = open_db_or_exit(args.db, fmt)
     try:
-        projects, auto_detected = resolve_scope(args, conn, fmt)
+        scope, auto_detected = resolve_scope(args, conn, fmt)
         fts_level = detect_fts_support(conn)
         sessions = search_sessions(
             conn,
             query=args.query,
             fts_level=fts_level,
             limit=limit,
-            projects=projects,
+            scope=scope,
             verbose=args.verbose,
             include_notifications=args.include_notifications,
             summary=args.summary,
@@ -217,7 +218,7 @@ def main():
         meta = {
             "query": args.query,
             "scope": {
-                "projects": projects,
+                "projects": scope.values if scope else None,
                 "auto_detected": auto_detected,
             },
             "has_more": len(sessions) == limit,

--- a/tests/claude-memory/test_search.py
+++ b/tests/claude-memory/test_search.py
@@ -13,6 +13,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "plugins" / "claude-memory" 
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from search_conversations import search_sessions
+from memory_lib.cli_common import ScopeFilter
 from memory_lib.db import SCHEMA, _migrate_columns, detect_fts_support
 
 
@@ -129,7 +130,7 @@ class TestSearchSessionsFTS:
             pytest.skip("FTS not available")
 
         results = search_sessions(search_db, "pytest", fts_level, limit=10,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         assert len(results) >= 2, "Should match sessions mentioning 'pytest'"
         uuids = {r["uuid"] for r in results}
         assert "sess-alpha-1" in uuids
@@ -141,14 +142,14 @@ class TestSearchSessionsFTS:
             pytest.skip("FTS not available")
 
         results = search_sessions(search_db, "database migration", fts_level, limit=10,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         assert len(results) >= 1
         assert any(r["uuid"] == "sess-alpha-2" for r in results)
 
     def test_empty_query_returns_empty(self, search_db):
         fts_level = detect_fts_support(search_db)
         results = search_sessions(search_db, "", fts_level, limit=10,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         assert results == []
 
     def test_limit_respected(self, search_db):
@@ -157,7 +158,7 @@ class TestSearchSessionsFTS:
             pytest.skip("FTS not available")
 
         results = search_sessions(search_db, "pytest", fts_level, limit=1,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         assert len(results) <= 1
 
     def test_project_filter(self, search_db):
@@ -166,7 +167,7 @@ class TestSearchSessionsFTS:
             pytest.skip("FTS not available")
 
         results = search_sessions(search_db, "pytest", fts_level, limit=10,
-                                  projects=["alpha"], verbose=False, include_notifications=False)
+                                  scope=ScopeFilter("name", ["alpha"]), verbose=False, include_notifications=False)
         assert all(r["project"] == "alpha" for r in results), "Should only return alpha project"
         assert len(results) >= 1
 
@@ -176,7 +177,7 @@ class TestSearchSessionsFTS:
             pytest.skip("FTS not available")
 
         results = search_sessions(search_db, "pytest fixtures", fts_level, limit=5,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         matching = [r for r in results if r["uuid"] == "sess-alpha-1"]
         assert len(matching) == 1
         session = matching[0]
@@ -192,10 +193,10 @@ class TestSearchSessionsFTS:
             pytest.skip("FTS not available")
 
         results = search_sessions(search_db, "pytest", fts_level, limit=10,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         projects_found = {r["project"] for r in results}
         assert len(projects_found) > 1, (
-            "projects=None should return sessions from multiple projects, not just one"
+            "scope=None should return sessions from multiple projects, not just one"
         )
 
     def test_unknown_project_returns_empty(self, search_db):
@@ -206,7 +207,7 @@ class TestSearchSessionsFTS:
             pytest.skip("FTS not available")
 
         results = search_sessions(search_db, "pytest", fts_level, limit=10,
-                                  projects=["nonexistent"], verbose=False, include_notifications=False)
+                                  scope=ScopeFilter("name", ["nonexistent"]), verbose=False, include_notifications=False)
         assert results == [], "Unknown project name should return empty list, not raise"
 
 
@@ -215,7 +216,7 @@ class TestSearchSessionsLIKE:
 
     def test_like_search_returns_results(self, search_db):
         results = search_sessions(search_db, "pytest", fts_level=None, limit=10,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         assert len(results) >= 2
         uuids = {r["uuid"] for r in results}
         assert "sess-alpha-1" in uuids
@@ -225,7 +226,7 @@ class TestSearchSessionsLIKE:
         # LIKE fallback ANDs all terms — "pytest fixtures" must match both words in aggregated_content.
         # Only sess-alpha-1 contains both "pytest" and "fixtures"; sess-beta-1 has pytest but not fixtures.
         results = search_sessions(search_db, "pytest fixtures", fts_level=None, limit=10,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         uuids = {r["uuid"] for r in results}
         assert uuids == {"sess-alpha-1"}, (
             "AND-logic should exclude sessions that match only one term"
@@ -233,34 +234,34 @@ class TestSearchSessionsLIKE:
 
     def test_like_project_filter(self, search_db):
         results = search_sessions(search_db, "pytest", fts_level=None, limit=10,
-                                  projects=["beta"], verbose=False, include_notifications=False)
+                                  scope=ScopeFilter("name", ["beta"]), verbose=False, include_notifications=False)
         assert all(r["project"] == "beta" for r in results)
 
     def test_like_empty_query(self, search_db):
         results = search_sessions(search_db, "", fts_level=None, limit=10,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         assert results == []
 
     def test_like_limit(self, search_db):
         results = search_sessions(search_db, "pytest", fts_level=None, limit=1,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         assert len(results) <= 1
 
     def test_like_projects_none_spans_all_projects(self, search_db):
         # Mirrors TestSearchSessionsFTS: LIKE path must also return cross-project results
-        # when projects=None, confirming the filter is absent in both code paths.
+        # when scope=None, confirming the filter is absent in both code paths.
         results = search_sessions(search_db, "pytest", fts_level=None, limit=10,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         projects_found = {r["project"] for r in results}
         assert len(projects_found) > 1, (
-            "projects=None should return sessions from multiple projects, not just one"
+            "scope=None should return sessions from multiple projects, not just one"
         )
 
     def test_like_unknown_project_returns_empty(self, search_db):
         # Prevents SQL errors from the LIKE path's IN clause when the project name
         # matches nothing — should return [] not raise.
         results = search_sessions(search_db, "pytest", fts_level=None, limit=10,
-                                  projects=["nonexistent"], verbose=False, include_notifications=False)
+                                  scope=ScopeFilter("name", ["nonexistent"]), verbose=False, include_notifications=False)
         assert results == [], "Unknown project name should return empty list, not raise"
 
 
@@ -270,7 +271,7 @@ class TestVerboseFlag:
     def test_verbose_false_omits_file_fields(self, search_db):
         # Prevents callers from accidentally relying on fields that are absent by default
         results = search_sessions(search_db, "pytest", fts_level=None, limit=5,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         assert len(results) >= 1
         for r in results:
             assert "files_modified" not in r
@@ -279,7 +280,7 @@ class TestVerboseFlag:
     def test_verbose_true_includes_file_fields(self, search_db):
         # Prevents regression where verbose path silently drops metadata
         results = search_sessions(search_db, "pytest", fts_level=None, limit=5,
-                                  projects=None, verbose=True, include_notifications=False)
+                                  scope=None, verbose=True, include_notifications=False)
         assert len(results) >= 1
         for r in results:
             assert "files_modified" in r
@@ -296,7 +297,7 @@ class TestIncludeNotificationsFlag:
         # Prevents notification noise from polluting context injection results
         results = search_sessions(search_db_with_notification, "pytest fixtures",
                                   fts_level=None, limit=5,
-                                  projects=None, verbose=False, include_notifications=False)
+                                  scope=None, verbose=False, include_notifications=False)
         matching = [r for r in results if r["uuid"] == "sess-alpha-1"]
         assert len(matching) == 1
         contents = [m["content"] for m in matching[0]["messages"]]
@@ -308,7 +309,7 @@ class TestIncludeNotificationsFlag:
         # Verifies the flag actually toggles behavior, not just that the default filters
         results = search_sessions(search_db_with_notification, "pytest fixtures",
                                   fts_level=None, limit=5,
-                                  projects=None, verbose=False, include_notifications=True)
+                                  scope=None, verbose=False, include_notifications=True)
         matching = [r for r in results if r["uuid"] == "sess-alpha-1"]
         assert len(matching) == 1
         contents = [m["content"] for m in matching[0]["messages"]]

--- a/tests/claude-memory/test_summary_mode.py
+++ b/tests/claude-memory/test_summary_mode.py
@@ -16,7 +16,7 @@ import sqlite3
 
 import pytest
 
-from memory_lib.cli_common import FANOUT_SUGGEST_CHARS, volume_flags, volume_signal
+from memory_lib.cli_common import FANOUT_SUGGEST_CHARS, ScopeFilter, volume_flags, volume_signal
 from memory_lib.formatting import format_json_sessions, format_markdown_session
 from recent_chats import get_recent_sessions
 from search_conversations import search_sessions
@@ -237,7 +237,7 @@ class TestGetRecentSessionsSummaryMode:
         self._setup_one_session(memory_db)
         results = get_recent_sessions(
             memory_db, limit=5, sort_order="desc",
-            before=None, after=None, projects=["testproj"],
+            before=None, after=None, scope=ScopeFilter("name", ["testproj"]),
             verbose=False, include_notifications=False,
         )
         assert len(results) == 1
@@ -249,7 +249,7 @@ class TestGetRecentSessionsSummaryMode:
         self._setup_one_session(memory_db)
         results = get_recent_sessions(
             memory_db, limit=5, sort_order="desc",
-            before=None, after=None, projects=["testproj"],
+            before=None, after=None, scope=ScopeFilter("name", ["testproj"]),
             verbose=False, include_notifications=False,
         )
         assert "summary" not in results[0]
@@ -259,7 +259,7 @@ class TestGetRecentSessionsSummaryMode:
         self._setup_one_session(memory_db, context_summary="Precomputed summary text.")
         results = get_recent_sessions(
             memory_db, limit=5, sort_order="desc",
-            before=None, after=None, projects=["testproj"],
+            before=None, after=None, scope=ScopeFilter("name", ["testproj"]),
             verbose=False, include_notifications=False,
             summary=True,
         )
@@ -271,7 +271,7 @@ class TestGetRecentSessionsSummaryMode:
         self._setup_one_session(memory_db)
         results = get_recent_sessions(
             memory_db, limit=5, sort_order="desc",
-            before=None, after=None, projects=["testproj"],
+            before=None, after=None, scope=ScopeFilter("name", ["testproj"]),
             verbose=False, include_notifications=False,
             summary=True,
         )
@@ -282,7 +282,7 @@ class TestGetRecentSessionsSummaryMode:
         self._setup_one_session(memory_db, context_summary=None)
         results = get_recent_sessions(
             memory_db, limit=5, sort_order="desc",
-            before=None, after=None, projects=["testproj"],
+            before=None, after=None, scope=ScopeFilter("name", ["testproj"]),
             verbose=False, include_notifications=False,
             summary=True,
         )
@@ -294,7 +294,7 @@ class TestGetRecentSessionsSummaryMode:
         self._setup_one_session(memory_db)
         results = get_recent_sessions(
             memory_db, limit=5, sort_order="desc",
-            before=None, after=None, projects=["testproj"],
+            before=None, after=None, scope=ScopeFilter("name", ["testproj"]),
             verbose=False, include_notifications=False,
             summary=True,
         )
@@ -376,7 +376,7 @@ class TestSearchSessionsSummaryMode:
         self._setup_searchable_session(memory_db)
         results = search_sessions(
             memory_db, query="findable", fts_level=None,
-            limit=5, projects=["searchproj"],
+            limit=5, scope=ScopeFilter("name", ["searchproj"]),
             verbose=False, include_notifications=False,
             summary=False,
         )
@@ -389,7 +389,7 @@ class TestSearchSessionsSummaryMode:
         self._setup_searchable_session(memory_db)
         results = search_sessions(
             memory_db, query="findable", fts_level=None,
-            limit=5, projects=["searchproj"],
+            limit=5, scope=ScopeFilter("name", ["searchproj"]),
             verbose=False, include_notifications=False,
             summary=True,
         )
@@ -410,7 +410,7 @@ class TestSearchSessionsSummaryMode:
         _seed_message(memory_db, sess_id, _get_last_branch_id(memory_db), content="unique keyword zxqwerty")
         results = search_sessions(
             memory_db, query="unique keyword zxqwerty", fts_level=None,
-            limit=5, projects=["searchproj2"],
+            limit=5, scope=ScopeFilter("name", ["searchproj2"]),
             verbose=False, include_notifications=False,
             summary=True,
         )
@@ -451,7 +451,7 @@ class TestMissingContextSummaryColumn:
         self._seed_then_drop_column(memory_db)
         results = get_recent_sessions(
             memory_db, limit=5, sort_order="desc",
-            before=None, after=None, projects=["oldproj"],
+            before=None, after=None, scope=ScopeFilter("name", ["oldproj"]),
             verbose=False, include_notifications=False,
         )
         assert len(results) == 1
@@ -462,7 +462,7 @@ class TestMissingContextSummaryColumn:
         self._seed_then_drop_column(memory_db)
         results = get_recent_sessions(
             memory_db, limit=5, sort_order="desc",
-            before=None, after=None, projects=["oldproj"],
+            before=None, after=None, scope=ScopeFilter("name", ["oldproj"]),
             verbose=False, include_notifications=False,
             summary=True,
         )
@@ -474,7 +474,7 @@ class TestMissingContextSummaryColumn:
         self._seed_then_drop_column(memory_db)
         results = search_sessions(
             memory_db, query="legacy", fts_level=None,
-            limit=5, projects=["oldproj"],
+            limit=5, scope=ScopeFilter("name", ["oldproj"]),
             verbose=False, include_notifications=False,
             summary=True,
         )


### PR DESCRIPTION
## Summary
- feat(memory): add --timeline + list_projects to recall CLI

## Changes
- `.claude-plugin/marketplace.json`
- `README.md`
- `plugins/claude-memory/.claude-plugin/plugin.json`
- `plugins/claude-memory/README.md`
- `plugins/claude-memory/skills/recall-conversations/scripts/list_projects.py`
- `plugins/claude-memory/skills/recall-conversations/scripts/recent_chats.py`

## Commits
- `87bc1e4` feat(memory): add --timeline + list_projects to recall CLI

## Diff Stat
```
.claude-plugin/marketplace.json                    |   2 +-
 README.md                                          |   2 +-
 plugins/claude-memory/.claude-plugin/plugin.json   |   2 +-
 plugins/claude-memory/README.md                    |   2 +-
 .../recall-conversations/scripts/list_projects.py  | 126 ++++++++++++++++++++
 .../recall-conversations/scripts/recent_chats.py   | 128 +++++++++++++++++++++
 6 files changed, 258 insertions(+), 4 deletions(-)
```
